### PR TITLE
Switch off temp-array checks for debug

### DIFF
--- a/cmake/project_toolchains.cmake
+++ b/cmake/project_toolchains.cmake
@@ -154,7 +154,7 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
 			"-O0"# -g -traceback -parallel -qopenmp -C -assume byterecl -heap-arrays 16384 -fpe0 -fPIC" 
 			"-g" 
       "-debug" "all"
-      "-check" "all"
+      "-check" "all,noarg_temp_created"
       #"-warn" "all"
       "-fp-stack-check"
       "-fstack-protector-all"


### PR DESCRIPTION
Disabling this turns off messages saying temporary arguments were created. These tend to flood the logs when debugging and are usually not very useful.