### PR TITLE
Ignore all build folders in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
 _deps
-build/
+build*/
 downloads/
 lib/
 lib64/


### PR DESCRIPTION
For users that have multiple build folders starting with build*/ . I don't think this should negatively affect anything, as it's unlikely that we will have directories with these names..