### PR TITLE
Fixed incorrect dependencies in Makefile

### DIFF
--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -22,13 +22,13 @@
 COBJS  := d1mach.o drc3jj.o hashtbl.o hashtbl_4Dmap.o powell_mod.o comm_hdf_mod.o sharp.o sort_utils.o ARS_mod.o math_tools.o locate_mod.o spline_1D_mod.o \
           spline_2D_mod.o InvSamp_mod.o comm_mpi_mod.o comm_system_backend.o comm_system_mod.o comm_map_mod.o comm_4D_map_mod.o \
           comm_defs.o comm_conviqt_mod.o \
-	  comm_utils.o comm_shared_arr_mod.o comm_huffman_mod.o comm_cr_utils.o comm_cr_precond_mod.o \
+          comm_utils.o comm_shared_arr_mod.o comm_huffman_mod.o comm_cr_utils.o comm_cr_precond_mod.o \
           comm_zodi_mod.o comm_shared_output_mod.o comm_status_mod.o \
-	  comm_bp_utils.o comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o \
-	  comm_cmb_comp_mod.o comm_cmb_relquad_comp_mod.o comm_powlaw_comp_mod.o comm_physdust_comp_mod.o comm_MBB_comp_mod.o \
+          comm_bp_utils.o comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o \
+          comm_cmb_comp_mod.o comm_cmb_relquad_comp_mod.o comm_powlaw_comp_mod.o comm_physdust_comp_mod.o comm_MBB_comp_mod.o \
           comm_freefree_comp_mod.o comm_line_comp_mod.o comm_spindust_comp_mod.o comm_spindust2_comp_mod.o \
           comm_md_comp_mod.o comm_template_comp_mod.o comm_ptsrc_comp_mod.o \
-	  comm_gain_mod.o comm_nonlin_mod.o comm_N_mod.o comm_N_rms_mod.o comm_N_QUcov_mod.o \
+          comm_gain_mod.o comm_nonlin_mod.o comm_N_mod.o comm_N_rms_mod.o comm_N_QUcov_mod.o \
           comm_B_mod.o comm_B_bl_mod.o comm_beam_mod.o \
           comm_F_int_mod.o comm_F_int_1D_mod.o comm_F_int_0D_mod.o comm_F_int_2D_mod.o \
           comm_fft_mod.o comm_tod_mod.o comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_gain_mod.o comm_tod_pointing_mod.o comm_tod_LFI_mod.o comm_tod_orbdipole_mod.o \
@@ -37,97 +37,78 @@ COBJS  := d1mach.o drc3jj.o hashtbl.o hashtbl_4Dmap.o powell_mod.o comm_hdf_mod.
 
 all : commander  sharp_test #hdftest sharp_test
 
-locate_mod.o :             math_tools.o
-spline_1D_mod.o :          locate_mod.o
-spline_2D_mod.o :          comm_utils.o
-InvSamp_mod.o :            spline_1D_mod.o
-comm_map_mod.o :           sharp.o comm_hdf_mod.o comm_param_mod.o
-comm_conviqt_mod.o :       sharp.o comm_map_mod.o comm_shared_arr_mod.o
-comm_hdf_mod.o :           comm_utils.o
-comm_fft_mod.o :           locate_mod.o comm_utils.o comm_param_mod.o
-comm_tod_mod.o :           comm_utils.o comm_fft_mod.o comm_map_mod.o comm_hdf_mod.o comm_param_mod.o \
-			   comm_huffman_mod.o comm_zodi_mod.o
-comm_tod_mapmaking_mod.o:  comm_tod_mod.o
-comm_tod_bandpass_mod.o:   comm_tod_mod.o
-comm_tod_noise_mod.o:      comm_tod_mod.o InvSamp_mod.o
-comm_tod_gain_mod.o:       comm_tod_mod.o comm_tod_noise_mod.o
-comm_tod_orbdipole_mod.o:  comm_map_mod.o comm_tod_mod.o
-comm_tod_pointing_mod.o:   comm_tod_mod.o
-comm_utils.o :             comm_defs.o spline_1D_mod.o
-comm_shared_arr_mod.o :    comm_utils.o
-comm_huffman_mod.o :       comm_utils.o
-comm_system_mod.o :        comm_system_backend.o
-comm_shared_output_mod.o : comm_system_mod.o
-comm_status_mod.o :        comm_shared_output_mod.o
-comm_utils.o :             sort_utils.o comm_system_mod.o sharp.o comm_mpi_mod.o
-ARS_mod.o :                sort_utils.o
-comm_bp_utils.o :          comm_utils.o
-comm_param_mod.o :         comm_utils.o comm_status_mod.o hashtbl.o
-comm_cr_utils.o :          comm_utils.o
-comm_cr_precond_mod.o :    comm_utils.o
-comm_comp_mod.o :          comm_bp_mod.o comm_param_mod.o comm_cr_utils.o comm_data_mod.o
-comm_Cl_mod.o :            comm_map_mod.o
-comm_diffuse_comp_mod.o :  comm_comp_mod.o comm_data_mod.o comm_F_int_mod.o comm_Cl_mod.o \
-                           comm_cr_precond_mod.o comm_beam_mod.o
-comm_template_comp_mod.o : comm_comp_mod.o
-comm_ptsrc_comp_mod.o :    comm_template_comp_mod.o comm_F_int_0D_mod.o comm_F_int_2D_mod.o \
-                           comm_hdf_mod.o comm_cr_precond_mod.o powell_mod.o
-comm_cmb_comp_mod.o :      comm_diffuse_comp_mod.o comm_F_int_0D_mod.o
-comm_cmb_relquad_comp_mod.o : comm_template_comp_mod.o comm_F_int_0D_mod.o
-comm_powlaw_comp_mod.o :   comm_diffuse_comp_mod.o comm_F_int_1D_mod.o
-comm_physdust_comp_mod.o : comm_diffuse_comp_mod.o comm_F_int_1D_mod.o
-comm_spindust_comp_mod.o : comm_diffuse_comp_mod.o comm_F_int_1D_mod.o
-comm_spindust2_comp_mod.o : comm_diffuse_comp_mod.o comm_F_int_1D_mod.o
-comm_MBB_comp_mod.o :      comm_diffuse_comp_mod.o comm_F_int_2D_mod.o
-comm_freefree_comp_mod.o : comm_diffuse_comp_mod.o comm_F_int_2D_mod.o
-comm_line_comp_mod.o :     comm_diffuse_comp_mod.o comm_F_line_mod.o
-comm_md_comp_mod.o :       comm_diffuse_comp_mod.o comm_F_line_mod.o
-comm_signal_mod.o :        comm_powlaw_comp_mod.o comm_cmb_comp_mod.o comm_cmb_relquad_comp_mod.o \
-                           comm_spindust_comp_mod.o comm_spindust2_comp_mod.o comm_MBB_comp_mod.o \
-                           comm_freefree_comp_mod.o comm_line_comp_mod.o \
-                           comm_md_comp_mod.o comm_template_comp_mod.o \
-                           comm_cr_mod.o comm_physdust_comp_mod.o
-comm_nonlin_mod.o :        comm_data_mod.o comm_comp_mod.o comm_chisq_mod.o \
-                           comm_gain_mod.o comm_output_mod.o comm_signal_mod.o
-comm_gain_mod.o :          comm_data_mod.o comm_comp_mod.o comm_chisq_mod.o
-comm_N_mod.o :             comm_param_mod.o
-comm_N_rms_mod.o :         comm_N_mod.o
-comm_noise_mod.o :         comm_N_rms_mod.o comm_N_QUcov_mod.o
-comm_bp_mod.o :            comm_bp_utils.o comm_param_mod.o
-comm_F_int_mod.o :         comm_utils.o
-comm_F_line_mod.o :        comm_F_int_mod.o 
-comm_F_int_0D_mod.o :      comm_F_int_mod.o 
-comm_F_int_1D_mod.o :      comm_F_int_mod.o spline_1D_mod.o
-comm_F_int_2D_mod.o :      comm_F_int_mod.o spline_2D_mod.o comm_utils.o
-comm_B_mod.o :             comm_map_mod.o
-comm_B_bl_mod.o :          comm_B_mod.o 
-comm_beam_mod.o :          comm_B_bl_mod.o
-comm_data_mod.o :          comm_map_mod.o comm_noise_mod.o comm_bp_mod.o comm_beam_mod.o comm_tod_mod.o \
-                           comm_tod_LFI_mod.o comm_tod_WMAP_mod.o
-comm_cr_mod.o :            comm_data_mod.o comm_comp_mod.o \
-                           comm_template_comp_mod.o comm_diffuse_comp_mod.o comm_output_mod.o
-comm_chisq_mod.o :         comm_data_mod.o comm_comp_mod.o
-comm_output_mod.o :        comm_comp_mod.o comm_hdf_mod.o comm_Cl_mod.o
-comm_4D_map_mod.o :        hashtbl_4Dmap.o comm_hdf_mod.o comm_utils.o
-comm_zodi_mod.o :          comm_utils.o comm_param_mod.o comm_bp_utils.o
-comm_tod_LFI_mod.o :       comm_tod_mod.o comm_shared_arr_mod.o comm_conviqt_mod.o comm_4D_map_mod.o comm_zodi_mod.o \
-                           comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_pointing_mod.o \
-			   comm_tod_orbdipole_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o 
-comm_tod_WMAP_mod.o :      comm_tod_mod.o comm_shared_arr_mod.o comm_conviqt_mod.o comm_4D_map_mod.o comm_zodi_mod.o \
-                           comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_pointing_mod.o \
-			   comm_tod_orbdipole_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o
-
-commander.o :              comm_signal_mod.o comm_data_mod.o comm_cr_mod.o comm_chisq_mod.o \
-                           comm_output_mod.o comm_nonlin_mod.o
-sharp_test.o :              ARS_mod.o
-
-
-
+ARS_mod.o                   : sort_utils.o
+comm_4D_map_mod.o           : comm_utils.o hashtbl_4Dmap.o comm_hdf_mod.o
+commander.o                 : comm_param_mod.o comm_data_mod.o comm_signal_mod.o comm_cr_mod.o comm_chisq_mod.o comm_output_mod.o comm_comp_mod.o comm_nonlin_mod.o
+comm_B_bl_mod.o             : comm_param_mod.o comm_map_mod.o comm_B_mod.o comm_utils.o spline_1D_mod.o
+comm_beam_mod.o             : comm_B_mod.o comm_B_bl_mod.o
+comm_B_mod.o                : comm_param_mod.o comm_map_mod.o spline_1D_mod.o
+comm_bp_mod.o               : comm_param_mod.o comm_bp_utils.o
+comm_bp_utils.o             : sort_utils.o comm_utils.o comm_hdf_mod.o
+comm_chisq_mod.o            : comm_data_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_ptsrc_comp_mod.o comm_template_comp_mod.o
+comm_Cl_mod.o               : comm_param_mod.o comm_map_mod.o math_tools.o comm_hdf_mod.o comm_bp_utils.o InvSamp_mod.o
+comm_cmb_comp_mod.o         : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_F_int_0D_mod.o comm_data_mod.o comm_bp_utils.o
+comm_cmb_relquad_comp_mod.o : comm_param_mod.o comm_comp_mod.o comm_template_comp_mod.o comm_F_int_mod.o comm_F_int_0D_mod.o comm_data_mod.o comm_bp_utils.o
+comm_comp_mod.o             : comm_param_mod.o comm_bp_utils.o comm_bp_mod.o comm_map_mod.o comm_cr_utils.o comm_data_mod.o comm_hdf_mod.o
+comm_conviqt_mod.o          : sharp.o comm_map_mod.o comm_utils.o comm_shared_arr_mod.o
+comm_cr_mod.o               : comm_comp_mod.o comm_data_mod.o comm_param_mod.o comm_diffuse_comp_mod.o comm_ptsrc_comp_mod.o comm_template_comp_mod.o comm_cr_utils.o comm_cr_precond_mod.o math_tools.o comm_output_mod.o
+comm_cr_precond_mod.o       : comm_utils.o
+comm_cr_utils.o             : comm_utils.o
+comm_data_mod.o             : comm_param_mod.o comm_bp_mod.o comm_noise_mod.o comm_beam_mod.o comm_map_mod.o comm_tod_mod.o comm_tod_LFI_mod.o comm_tod_WMAP_mod.o locate_mod.o
+comm_diffuse_comp_mod.o     : comm_param_mod.o comm_comp_mod.o comm_map_mod.o comm_data_mod.o comm_F_int_mod.o comm_Cl_mod.o math_tools.o comm_cr_utils.o comm_cr_precond_mod.o comm_hdf_mod.o InvSamp_mod.o powell_mod.o comm_beam_mod.o
+comm_fft_mod.o              : comm_utils.o comm_param_mod.o locate_mod.o
+comm_F_int_0D_mod.o         : comm_F_int_mod.o comm_comp_mod.o comm_bp_mod.o comm_utils.o
+comm_F_int_1D_mod.o         : comm_F_int_mod.o comm_comp_mod.o comm_bp_mod.o spline_1D_mod.o comm_utils.o
+comm_F_int_2D_mod.o         : comm_F_int_mod.o comm_comp_mod.o comm_bp_mod.o spline_2D_mod.o comm_utils.o
+comm_F_int_mod.o            : comm_utils.o comm_bp_mod.o
+comm_F_line_mod.o           : comm_F_int_mod.o comm_comp_mod.o comm_bp_mod.o comm_utils.o
+comm_F_mod.o                : comm_comp_mod.o comm_param_mod.o comm_map_mod.o comm_bp_mod.o comm_F_int_mod.o comm_F_int_1D_mod.o
+comm_freefree_comp_mod.o    : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_1D_mod.o comm_data_mod.o
+comm_gain_mod.o             : comm_param_mod.o comm_data_mod.o comm_comp_mod.o
+comm_hdf_mod.o              : comm_utils.o
+comm_huffman_mod.o          : comm_utils.o
+comm_line_comp_mod.o        : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_F_line_mod.o comm_data_mod.o comm_bp_utils.o
+comm_map_mod.o              : sharp.o comm_hdf_mod.o comm_param_mod.o
+comm_MBB_comp_mod.o         : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_2D_mod.o comm_data_mod.o
+comm_md_comp_mod.o          : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_F_line_mod.o comm_data_mod.o comm_bp_utils.o
+comm_N_mod.o                : comm_param_mod.o comm_map_mod.o
+comm_noise_mod.o            : comm_N_mod.o comm_N_rms_mod.o comm_N_QUcov_mod.o
+comm_nonlin_mod.o           : comm_param_mod.o comm_data_mod.o comm_comp_mod.o comm_chisq_mod.o comm_gain_mod.o comm_line_comp_mod.o comm_diffuse_comp_mod.o comm_signal_mod.o
+comm_N_QUcov_mod.o          : comm_N_mod.o comm_param_mod.o comm_map_mod.o
+comm_N_rms_mod.o            : comm_N_mod.o comm_param_mod.o comm_map_mod.o
+comm_output_mod.o           : comm_param_mod.o comm_comp_mod.o comm_chisq_mod.o comm_hdf_mod.o
+comm_param_mod.o            : comm_utils.o comm_status_mod.o hashtbl.o
+comm_physdust_comp_mod.o    : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_1D_mod.o comm_data_mod.o spline_2D_mod.o
+comm_powlaw_comp_mod.o      : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_1D_mod.o comm_data_mod.o
+comm_ptsrc_comp_mod.o       : math_tools.o comm_param_mod.o comm_comp_mod.o comm_F_int_mod.o comm_F_int_0D_mod.o comm_F_int_2D_mod.o comm_data_mod.o comm_hdf_mod.o comm_cr_utils.o comm_cr_precond_mod.o locate_mod.o spline_1D_mod.o InvSamp_mod.o powell_mod.o
+comm_shared_arr_mod.o       : comm_utils.o
+comm_shared_output_mod.o    : comm_utils.o comm_system_mod.o
+comm_signal_mod.o           : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_cmb_comp_mod.o comm_cmb_relquad_comp_mod.o comm_powlaw_comp_mod.o comm_physdust_comp_mod.o comm_spindust_comp_mod.o comm_spindust2_comp_mod.o comm_MBB_comp_mod.o comm_freefree_comp_mod.o comm_line_comp_mod.o comm_md_comp_mod.o comm_template_comp_mod.o comm_ptsrc_comp_mod.o comm_cr_mod.o comm_cr_utils.o comm_hdf_mod.o comm_data_mod.o comm_chisq_mod.o
+comm_spindust2_comp_mod.o   : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_2D_mod.o comm_data_mod.o spline_2D_mod.o
+comm_spindust_comp_mod.o    : comm_param_mod.o comm_comp_mod.o comm_diffuse_comp_mod.o comm_map_mod.o comm_F_int_1D_mod.o comm_data_mod.o spline_1D_mod.o
+comm_status_mod.o           : comm_utils.o comm_system_mod.o comm_shared_output_mod.o
+comm_task_mod.o             : comm_utils.o
+comm_template_comp_mod.o    : math_tools.o comm_param_mod.o comm_comp_mod.o comm_F_int_mod.o comm_data_mod.o comm_hdf_mod.o comm_cr_utils.o comm_cr_precond_mod.o locate_mod.o spline_1D_mod.o
+comm_tod_bandpass_mod.o     : comm_tod_mod.o comm_utils.o
+comm_tod_gain_mod.o         : comm_tod_mod.o comm_tod_noise_mod.o comm_utils.o
+comm_tod_LFI_mod.o          : comm_tod_mod.o comm_param_mod.o comm_map_mod.o comm_conviqt_mod.o comm_huffman_mod.o comm_hdf_mod.o comm_fft_mod.o comm_shared_arr_mod.o spline_1D_mod.o comm_4D_map_mod.o comm_zodi_mod.o comm_tod_mapmaking_mod.o comm_tod_pointing_mod.o comm_tod_gain_mod.o comm_tod_bandpass_mod.o comm_tod_orbdipole_mod.o comm_utils.o
+comm_tod_mapmaking_mod.o    : comm_tod_mod.o comm_utils.o comm_shared_arr_mod.o comm_map_mod.o
+comm_tod_mod.o              : comm_utils.o comm_param_mod.o comm_hdf_mod.o comm_map_mod.o comm_fft_mod.o comm_huffman_mod.o comm_conviqt_mod.o comm_zodi_mod.o
+comm_tod_noise_mod.o        : comm_tod_mod.o comm_utils.o InvSamp_mod.o
+comm_tod_orbdipole_mod.o    : comm_utils.o comm_defs.o comm_map_mod.o comm_tod_mod.o spline_1D_mod.o
+comm_tod_pointing_mod.o     : comm_tod_mod.o comm_map_mod.o comm_utils.o
+comm_tod_WMAP_mod.o         : comm_tod_mod.o comm_param_mod.o comm_map_mod.o comm_conviqt_mod.o comm_huffman_mod.o comm_hdf_mod.o comm_fft_mod.o comm_shared_arr_mod.o spline_1D_mod.o comm_4D_map_mod.o comm_zodi_mod.o comm_tod_mapmaking_mod.o comm_tod_pointing_mod.o comm_tod_gain_mod.o comm_tod_bandpass_mod.o comm_tod_orbdipole_mod.o comm_utils.o
+comm_utils.o                : comm_system_mod.o comm_defs.o sort_utils.o spline_1D_mod.o comm_mpi_mod.o
+comm_zodi_mod.o             : comm_utils.o comm_param_mod.o
+InvSamp_mod.o               : spline_1D_mod.o
+sharp_test.o                : comm_map_mod.o comm_param_mod.o ARS_mod.o
+spline_1D_mod.o             : locate_mod.o math_tools.o
+spline_2D_mod.o             : spline_1D_mod.o math_tools.o comm_utils.o
 
 commander : libcommander.a commander.o
 	$(MPF90) -o commander commander.o $(LINK) $(MPFCLIBS)
 
-sharp_test : sharp.o sharp_test.o
+sharp_test : sharp.o sharp_test.o libcommander.a
 	$(MPF90) -o sharp_test sharp_test.o sharp.o $(LINK) $(MPFCLIBS)
 
 hdftest : hdftest.o 

--- a/commander3/src/comm_hdf_mod.f90
+++ b/commander3/src/comm_hdf_mod.f90
@@ -1971,14 +1971,8 @@ contains
     type(hdf_file) :: file
     character(len=*), intent(in) :: setname
     character(len=*) , intent(in) :: val
-    integer(hid_t) :: str_dtype
-    integer :: hdferr
-
-    call H5Tcopy_f(H5T_FORTRAN_S1, str_dtype, hdferr)
-    call H5Tset_size_f(str_dtype, int(len_trim(val), size_t), hdferr)
-
-    call create_hdf_set(file, setname, shape(val), str_dtype)
-    call h5dwrite_f(file%sethandle, str_dtype, trim(val), int(shape(val), hsize_t), file%status)
+    call create_hdf_set(file, setname, shape(val), H5T_C_S1)
+    call h5dwrite_f(file%sethandle, H5T_NATIVE_CHARACTER, val, int(shape(val),hsize_t), file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot write data set")
   end subroutine
 


### PR DESCRIPTION
This fixes the dependencies for the files in the standard Makefile to reflect what they actually depend on. With this, one can:

1. Do parallel makes with make -j 10 for example, without anything breaking. Note that many files depend on each other, so you won't see 10 things happening at once all the time, but it's still a good speedup.
2. Do make without doing make clean when you've changed something. Only what's necessary will be rebuilt.