### PR TITLE
disable polarisation quadrupole suppression when `enable_tod_simulations` is activated

### DIFF
--- a/commander3/src/commander.f90
+++ b/commander3/src/commander.f90
@@ -677,7 +677,11 @@ contains
           do j = 1, data(i)%tod%ndet
              !s_sky(j,k)%p => comm_map(data(i)%info)
              !call get_sky_signal(i, j, s_sky(j,k)%p, mono=.false.) 
-             call get_sky_signal(i, j, s_sky(j,k)%p, mono=.false., cmb_pol=.false.) 
+             if (cpar%enable_tod_simulations) then
+                 call get_sky_signal(i, j, s_sky(j,k)%p, mono=.false.)
+             else
+                 call get_sky_signal(i, j, s_sky(j,k)%p, mono=.false., cmb_pol=.false.)
+             end if
              !s_sky(j,k)%p%map = s_sky(j,k)%p%map + 5.d0
              !0call s_sky(j,k)%p%smooth(0.d0, 180.d0)
           end do


### PR DESCRIPTION
I've stumbled over the issue that for an input map with a very high (unphysically so) polarisation quadrupole (or even less physical, a high dipole), we don't recover the input map. See #107 for more details on this issue.

This PR ensures that `cmb_pol` does not get included in the call to `get_sky_signal` when running a simulation (i.e. when `enable_tod_simulations=true`).

This PR fixes #107. It does not properly fix the issue, but if I understand correctly this is as good as we can make it with Planck alone. Including other data (e.g. WMAP) might be more helpful. Hence, issue #107 should be kept in mind nonetheless when thinking about potential biases in the low polarisation multipoles.