### PR TITLE
CGmap 

### DIFF
--- a/cmake/projects/commander3.cmake
+++ b/cmake/projects/commander3.cmake
@@ -63,6 +63,7 @@ set(sources
 	${COMMANDER3_SOURCE_DIR}/comm_tod_pixcache_smod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_driver_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_mapmaking_mod.f90
+	${COMMANDER3_SOURCE_DIR}/comm_tod_cgmap_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_lfi_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_lfi_smod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_hfi_mod.f90

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -275,6 +275,7 @@ comm_tod_noise_mod.o        : comm_tod_mod.o invsamp_mod.o
 comm_tod_gain_mod.o         : comm_tod_noise_mod.o 
    comm_tod_gain_smod.o     : comm_tod_gain_mod.o
 comm_tod_mapmaking_mod.o    : comm_tod_mod.o
+comm_tod_cgmap_mod.o        : comm_utils.o
 comm_tod_bandpass_mod.o     : comm_tod_mod.o 
 
 comm_zodi_comp_mod.o        : comm_param_mod.o comm_hdf_mod.o
@@ -292,7 +293,7 @@ comm_tod_wmap_mod.o         : comm_tod_driver_mod.o
 comm_tod_dirbe_mod.o        : comm_tod_driver_mod.o comm_tod_pixhist_mod.o
 comm_tod_hfi_mod.o          : comm_tod_driver_mod.o comm_tod_pixhist_mod.o
 comm_tod_inst_mod.o         : comm_tod_lb_mod.o comm_tod_lfi_mod.o comm_tod_spider_mod.o comm_tod_wmap_mod.o comm_tod_dirbe_mod.o comm_tod_hfi_mod.o #comm_tod_quiet_mod.o
-comm_tod_akari_mod.o        : comm_tod_driver_mod.o comm_tod_pixhist_mod.o
+comm_tod_akari_mod.o        : comm_tod_driver_mod.o comm_tod_pixhist_mod.o comm_tod_cgmap_mod.o
    comm_tod_akari_smod.o        : comm_tod_akari_mod.o
 
 comm_data_mod.o             : comm_noise_mod.o comm_bp_mod.o comm_beam_mod.o comm_tod_inst_mod.o comm_dust_extinction_mod.o 

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -100,6 +100,7 @@ F90SOURCES=hashtbl.f90 \
            comm_tod_mod.f90 \
              comm_tod_pixcache_smod.f90 \
            comm_tod_mapmaking_mod.f90 \
+           comm_tod_cgmap_mod.f90 \
            comm_tod_bandpass_mod.f90 \
 	   comm_tod_crosstalk_mod.f90 \
 	   comm_tod_Tbol_mod.f90 \
@@ -249,7 +250,7 @@ comm_tod_adc_binfit_mod.o   : math_tools.o comm_param_mod.o
 comm_tod_adc_binfit_smod.o         : comm_tod_adc_binfit_mod.o
 comm_tod_bandpass_mod.o     : comm_tod_mod.o comm_utils.o comm_status_mod.o
 comm_tod_crosstalk_mod.o    : comm_utils.o comm_status_mod.o
-comm_tod_Tbol_mod.o         : comm_tod_mod.o comm_status_mod.o
+comm_tod_Tbol_mod.o         : comm_utils.o comm_status_mod.o
 comm_tod_cray_mod.o         : comm_param_mod.o
 comm_tod_dirbe_mod.o        : comm_tod_driver_mod.o comm_tod_mapmaking_mod.o
 comm_tod_driver_mod.o       : comm_tod_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o comm_tod_pointing_mod.o comm_tod_bandpass_mod.o comm_tod_orbdipole_mod.o comm_tod_simulations_mod.o comm_tod_jump_mod.o comm_tod_adc_mod.o comm_zodi_mod.o comm_tod_cray_mod.o comm_shared_arr_mod.o comm_huffman_mod.o comm_4d_map_mod.o comm_tod_adc_binfit_mod.o comm_tod_objctr_mod.o

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -276,7 +276,7 @@ comm_tod_noise_mod.o        : comm_tod_mod.o invsamp_mod.o
 comm_tod_gain_mod.o         : comm_tod_noise_mod.o 
    comm_tod_gain_smod.o     : comm_tod_gain_mod.o
 comm_tod_mapmaking_mod.o    : comm_tod_mod.o
-comm_tod_cgmap_mod.o        : comm_utils.o
+comm_tod_cgmap_mod.o        : comm_tod_mod.o
 comm_tod_bandpass_mod.o     : comm_tod_mod.o 
 
 comm_zodi_comp_mod.o        : comm_param_mod.o comm_hdf_mod.o

--- a/commander3/src/comm_map_mod.f90
+++ b/commander3/src/comm_map_mod.f90
@@ -100,6 +100,7 @@ module comm_map_mod
      procedure     :: smooth
      procedure     :: map2pix
      procedure     :: bcast_fullsky_map
+     procedure     :: bcast_fullsky_from_root
      procedure     :: bcast_fullsky_alms
      procedure     :: distribute_alms
      procedure     :: get_alm
@@ -1731,6 +1732,38 @@ subroutine tod2file_dp3(filename,d)
        call mpi_recv(vals, np*nmaps, MPI_REAL,    0, 98, self%info%comm, mpistat, ierr)
     end if
   end subroutine map2pix
+
+  subroutine bcast_fullsky_from_root(self, map)
+    implicit none
+    class(comm_map),                    intent(inout)            :: self
+    real(dp),         dimension(0:,1:), intent(in),    optional  :: map
+
+    integer(i4b) :: i, nmaps, npix, np, ierr
+    real(dp),     allocatable, dimension(:,:) :: buffer
+    integer(i4b), allocatable, dimension(:)   :: p
+    integer(i4b), dimension(MPI_STATUS_SIZE)  :: mpistat
+
+    npix  = self%info%npix
+    nmaps = self%info%nmaps
+
+    ! Distribute to each core according to pix
+    if (self%info%myid == 0) then
+       self%map = map(self%info%pix,:)
+       do i = 1, self%info%nprocs-1
+          call mpi_recv(np,        1,       MPI_INTEGER, i, 98, self%info%comm, mpistat, ierr)
+          allocate(p(np), buffer(np,nmaps))
+          call mpi_recv(p,  np,       MPI_INTEGER, i, 98, self%info%comm, mpistat, ierr)
+          buffer = map(p,:)
+          call mpi_send(buffer, np*nmaps, MPI_DOUBLE_PRECISION,    i, 98, self%info%comm, ierr)
+          deallocate(p,buffer)
+       end do
+    else
+       np = self%info%np
+       call mpi_send(np,             1,        MPI_INTEGER,          0, 98, self%info%comm, ierr)
+       call mpi_send(self%info%pix,  np,       MPI_INTEGER,          0, 98, self%info%comm, ierr)
+       call mpi_recv(self%map,       np*nmaps, MPI_DOUBLE_PRECISION, 0, 98, self%info%comm, mpistat, ierr)
+    end if
+  end subroutine bcast_fullsky_from_root
 
   
   subroutine bcast_fullsky_alms(self)

--- a/commander3/src/comm_tod_Tbol_mod.f90
+++ b/commander3/src/comm_tod_Tbol_mod.f90
@@ -29,8 +29,8 @@ module comm_tod_Tbol_mod
 
   type :: comm_Tbol
   contains
-    procedure :: estimate_Tbol_params
-    procedure :: convolve_Tbol
+    procedure :: estimate_params
+    procedure :: convolve
   end type comm_Tbol   
 
   interface comm_Tbol
@@ -53,17 +53,16 @@ contains
   end function Tbol_constructor
  
   ! estimates Tbol parameters for each detector
-  subroutine estimate_Tbol_params(self)
+  subroutine estimate_params(self)
     implicit none
     class(comm_Tbol), intent(inout)      :: self
-  end subroutine estimate_Tbol_params
+  end subroutine estimate_params
 
   ! Routine for convolving with bolometer transfer function, tod = T * tod
-  subroutine convolve_Tbol(self, det, tod)
+  subroutine convolve(self, tod)
     implicit none
-    class(comm_Tbol),                            intent(in)    :: self
-    integer(i4b),                                intent(in)    :: det
-    real(sp),         allocatable, dimension(:), intent(inout) :: tod
-  end subroutine convolve_Tbol
+    class(comm_Tbol),               intent(in)    :: self
+    real(sp),         dimension(:), intent(inout) :: tod
+  end subroutine convolve
 
 end module comm_tod_Tbol_mod

--- a/commander3/src/comm_tod_akari_mod.f90
+++ b/commander3/src/comm_tod_akari_mod.f90
@@ -33,6 +33,7 @@ module comm_tod_akari_mod
   use comm_tod_driver_mod
   use comm_tod_pixhist_mod
   use comm_tod_mapmaking_mod
+  use comm_tod_cgmap_mod
    implicit none
 
    private

--- a/commander3/src/comm_tod_akari_mod.f90
+++ b/commander3/src/comm_tod_akari_mod.f90
@@ -40,10 +40,12 @@ module comm_tod_akari_mod
    public comm_akari_tod
 
    type, extends(comm_tod) :: comm_akari_tod
+      ! Ingunn: Add binned residual params here
    contains
      procedure     :: process_tod             => process_akari_tod
      procedure     :: apply_fast_flags_inst   => apply_fast_flags_akari
      procedure     :: construct_corrtemp_inst => construct_corrtemp_akari
+     procedure     :: sample_binned_residual
    end type comm_akari_tod
 
    interface comm_akari_tod
@@ -172,6 +174,28 @@ interface
     class(comm_scandata),  intent(inout)          :: sd
     integer(i4b),          intent(in),   optional :: det
   end subroutine construct_corrtemp_akari
+
+  module subroutine sample_binned_residual(self, sd)
+     ! Sample an AKARI binned residual
+     !
+     ! Task: Bin TOD residual into a 60-sec template. Full scan? Shorter sub-segments?
+     !       Fill in sd%s_inst(k,l) with the full-scan template
+     !
+     !  Arguments:
+     !  ----------
+     !  self: comm_tod object
+     !
+     !  sd:  comm_scandata
+     !
+     !  Returns:
+     !  --------
+     !  self: updates module variables
+     !       
+     implicit none
+     class(comm_akari_tod), intent(in)             :: self
+     class(comm_scandata),  intent(inout)          :: sd
+
+   end subroutine sample_binned_residual
 
 
    

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -227,7 +227,7 @@ contains
       character(len=512)  :: prefix, postfix, prefix4D, prefix_atlas, postfix_atlas
       character(len=512), allocatable, dimension(:) :: slist
       real(sp),              dimension(9)       :: flag_threshold
-      real(sp), allocatable, dimension(:)       :: procmask, procmask2, procmask_zodi
+      real(sp), allocatable, dimension(:)       :: procmask, procmask2, procmask_zodi, sigma0
       real(sp), allocatable, dimension(:,:,:)   :: d_calib
       real(sp), allocatable, dimension(:,:,:,:) :: map_sky, m_gain
       real(dp), allocatable, dimension(:,:)     :: chisq_S, m_buf
@@ -237,6 +237,9 @@ contains
       real(dp), allocatable, dimension(:, :)    :: res_tot ! (n_tod_tot, ndet)
       real(dp), allocatable, dimension(:)       :: mask_tot ! (n_tod_tot)
       type(hdf_file) :: tod_file
+
+      integer(i4b), dimension(1) :: col_def = [1]  ! Only T
+      class(comm_cgmap), pointer :: cgmap
 
       call int2string(iter, ctext)
       call update_status(status, "tod_start"//ctext)
@@ -344,8 +347,11 @@ contains
          slist   = ''
       end if
 
+      ! Initialize CG mapmaker
+      cgmap => comm_cgmap(self%info%comm, self%nside, self%ndet, self%scans%ntod, col_def, self%pixcache%ind2pix)
+      
       ! Perform loop over scans
-      if (self%myid == 0) write(*,*) '   --> Sampling ncorr, xi_n, maps' 
+      if (self%myid == 0) write(*,*) '   --> Sampling ncorr, xi_n, maps'
       do i = 1, self%nscan
 
          ! Skip scan if no accepted data
@@ -409,6 +415,14 @@ contains
          d_calib = 0.d0
          call compute_calibrated_data(self, i, sd, d_calib)    
 
+         ! Feed CG mapmaker calibrated and inpainted data
+         allocate(sigma0(sd%ndet))
+         do j = 1, sd%ndet
+            sigma0(j) = self%scans(i)%d(j)%N_psd%sigma0
+         end do
+         call cgmap%load_data(i, transpose(d_calib(1,:,:)), transpose(sd%ind(:,:,1)), transpose(sd%mask), sigma0)
+         deallocate(sigma0)
+                  
          !write(*,*) "Scan = ", self%scanid(i), ', num moon = ', count(iand(sd%flag,2)==2)
          
          ! For debugging: write TOD to hdf
@@ -477,7 +491,7 @@ contains
          end if
       end if
       map_out%map = binmap%outmaps(1)%p%map
-
+      
       ! Sample bandpass parameters
       if (sample_rel_bandpass .or. sample_abs_bandpass) then
          call sample_bp(self, handle, chisq_S, delta)
@@ -514,6 +528,12 @@ contains
       !       call binmap%outmaps(8+i)%p%writeFITS(trim(prefix)//'zodi_'//trim(zodi_comp_names(i))//trim(postfix))
       !    end do
       ! endif
+
+      ! Solve for CG map
+      call cgmap%solve(map_out)
+      call dealloc_cgmap(cgmap)
+      call map_out%writeFITS(trim(prefix)//'cgmap'//trim(postfix))
+      !call rms_out%writeFITS(trim(prefix)//'rms'//trim(postfix))
 
       ! Clean up
       call binmap%dealloc()

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -227,7 +227,7 @@ contains
       character(len=512)  :: prefix, postfix, prefix4D, prefix_atlas, postfix_atlas
       character(len=512), allocatable, dimension(:) :: slist
       real(sp),              dimension(9)       :: flag_threshold
-      real(sp), allocatable, dimension(:)       :: procmask, procmask2, procmask_zodi, sigma0
+      real(sp), allocatable, dimension(:)       :: procmask, procmask2, procmask_zodi
       real(sp), allocatable, dimension(:,:,:)   :: d_calib
       real(sp), allocatable, dimension(:,:,:,:) :: map_sky, m_gain
       real(dp), allocatable, dimension(:,:)     :: chisq_S, m_buf
@@ -415,13 +415,8 @@ contains
          d_calib = 0.d0
          call compute_calibrated_data(self, i, sd, d_calib)    
 
-         ! Feed CG mapmaker calibrated and inpainted data
-         allocate(sigma0(sd%ndet))
-         do j = 1, sd%ndet
-            sigma0(j) = self%scans(i)%d(j)%N_psd%sigma0
-         end do
-         call cgmap%load_data(i, transpose(d_calib(1,:,:)), transpose(sd%ind(:,:,1)), transpose(sd%mask), sigma0)
-         deallocate(sigma0)
+         ! Feed CG mapmaker calibrated and cleaned data
+         call cgmap%load_data(i, self, sd, d_calib(1,:,:))
                   
          !write(*,*) "Scan = ", self%scanid(i), ', num moon = ', count(iand(sd%flag,2)==2)
          

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -347,8 +347,8 @@ contains
          slist   = ''
       end if
 
-      ! Initialize CG mapmaker
-      cgmap => comm_cgmap(self%info%comm, self%nside, self%ndet, self%scans%ntod, col_def, self%pixcache%ind2pix)
+      ! Initialize CG mapmaker, maptype = 1 = T-only
+      cgmap => comm_cgmap(1, self%info%comm, self%nside, self%ndet, self%scans%ntod, self%pixcache%ind2pix)
       
       ! Perform loop over scans
       if (self%myid == 0) write(*,*) '   --> Sampling ncorr, xi_n, maps'
@@ -610,26 +610,23 @@ contains
    end subroutine apply_fast_flags_akari
 
    module subroutine construct_corrtemp_akari(self, sd, det)
-     !  Construct an AKARI instrument-specific correction template
+     ! Construct an AKARI instrument-specific correction template
      !
-     ! Ingunn: Bin TOD residual into a 60-sec template. Full scan? Shorter sub-segments?
-     !         Fill in sd%s_inst(k,l) with the full-scan template
+     ! Ingunn: Project binned residual params into sd%s_inst(k,l) 
      !
      !  Arguments:
      !  ----------
      !  self: comm_tod object
      !
-     !  scan: int
-     !       scan number
-     !  pix: int
-     !       index for pixel
-     !  psi: int
-     !       integer label for polarization angle
+     !  sd:  comm_scandata
+     !       Decompressed data for current scan (defined in comm_tod_mod)
+     !  det: int
+     !       detector index (optional)
      !
      !  Returns:
      !  --------
-     !  s:   real (sp)
-     !       output template timestream
+     !  self:  comm_akari_to
+     !       Updates sd%s_inst
      implicit none
      class(comm_akari_tod), intent(in)             :: self
      class(comm_scandata),  intent(inout)          :: sd
@@ -650,12 +647,52 @@ contains
            ! t = modulo(self%scans(scan)%t0(2)/65536.d0 + (k-1)*dt,t_tot)    ! OBT is stored in units of 2**-16 = 1/65536 sec
            ! b = min(int(t*nbin),nbin-1)
            ! sd%s_inst(k,l) = self%spike_amplitude(scan,j) * self%spike_templates(b,j)
-           sd%s_inst(k,l) = 0.
+           sd%s_inst(k,j) = 0.
         end do
      end do
 
    end subroutine construct_corrtemp_akari
-   
+
+   module subroutine sample_binned_residual(self, sd)
+     ! Sample an AKARI binned residual
+     !
+     ! Ingunn: Bin TOD residual into a 60-sec template. Full scan? Shorter sub-segments?
+     !         Fill in sd%s_inst(k,l) with the full-scan template
+     !
+     !  Arguments:
+     !  ----------
+     !  self: comm_tod object
+     !
+     !  sd:  comm_scandata
+     !
+     !  Returns:
+     !  --------
+     !  self: updates module variables
+     !       
+     implicit none
+     class(comm_akari_tod), intent(in)             :: self
+     class(comm_scandata),  intent(inout)          :: sd
+
+     integer(i4b) :: i, j, k, l, nbin, b, ndet, scan
+     real(dp)     :: dt
+
+     scan  = sd%scan
+     dt    = 1.d0/self%samprate   ! Sample time
+     ndet  = sd%ndet
+
+     do j = 1, ndet
+        if (.not. self%scans(scan)%d(j)%accept) cycle
+        do k = 1, self%scans(scan)%ntod
+           ! Example from LFI
+           ! t = modulo(self%scans(scan)%t0(2)/65536.d0 + (k-1)*dt,t_tot)    ! OBT is stored in units of 2**-16 = 1/65536 sec
+           ! b = min(int(t*nbin),nbin-1)
+           ! sd%s_inst(k,l) = self%spike_amplitude(scan,j) * self%spike_templates(b,j)
+           sd%s_inst(k,j) = 0.
+        end do
+     end do
+
+   end subroutine sample_binned_residual
+
    
    
 

--- a/commander3/src/comm_tod_cgmap_mod.f90
+++ b/commander3/src/comm_tod_cgmap_mod.f90
@@ -30,9 +30,8 @@ module comm_tod_cgmap_mod
   
   type comm_cgmap
      integer(i4b)  :: comm, myid, nprocs
-     integer(i4b)  :: ndet, ncol, nside, npix, nscan, ntod, nobs
+     integer(i4b)  :: maptype, ndet, ncol, nside, npix, nscan, ntod, nobs
      logical(lgt),            allocatable, dimension(:,:) :: accept      ! Accept status, (ndet,nscan)
-     integer(i4b),            allocatable, dimension(:)   :: col_def     ! Column Stokes definition; T_full=1, Q_full=2, U_full=3, S_det=det+3, T_det=-det
      integer(i4b),            allocatable, dimension(:)   :: ind_scan    ! Index range for each scan (0:nscan)
      real(dp),                allocatable, dimension(:,:) :: x           ! Final full-sky map; only stored by root processor
      real(dp),                allocatable, dimension(:,:) :: invM        ! Diagonal preconditioner
@@ -40,6 +39,7 @@ module comm_tod_cgmap_mod
      real(sp),                allocatable, dimension(:,:) :: tod         ! Stacked, calibrated and in-painted TOD, (ndet,nscan*ntod)
      real(sp),                allocatable, dimension(:,:) :: invN        ! 1/sigma**2 per scan, (ndet,nscan)
      integer(i4b),            allocatable, dimension(:,:) :: ind         ! Stacked pixel index numbers, (ndet,nscan*ntod)
+     integer(i4b),            allocatable, dimension(:,:) :: psi         ! Stacked psi index numbers, (ndet,nscan*ntod)
      integer(i4b),            allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
      type(comm_crosstalk),                 pointer        :: W_S         ! Signal crosstalk matrix
      type(comm_crosstalk),                 pointer        :: W_N         ! Noise crosstalk matrix
@@ -66,11 +66,10 @@ module comm_tod_cgmap_mod
     
 contains
 
-  function constructor_cgmap(comm, nside, ndet, ntod_scan, col_def, ind2pix, W_S, W_N, Tbol) result(c)
+  function constructor_cgmap(maptype, comm, nside, ndet, ntod_scan, ind2pix, W_S, W_N, Tbol) result(c)
     implicit none
-    integer(i4b),                       intent(in) :: comm, nside, ndet
+    integer(i4b),                       intent(in) :: maptype, comm, nside, ndet
     integer(i4b),         dimension(:), intent(in) :: ntod_scan
-    integer(i4b),         dimension(:), intent(in) :: col_def
     integer(i4b),         dimension(:), intent(in) :: ind2pix
     type(comm_crosstalk), target,       intent(in), optional :: W_S
     type(comm_crosstalk), target,       intent(in), optional :: W_N
@@ -84,17 +83,23 @@ contains
     call mpi_comm_rank(comm, c%myid, ierr)
     call mpi_comm_size(comm, c%nprocs, ierr) 
     
+    c%maptype   = maptype
     c%nside     = nside
     c%npix      = 12*c%nside**2
     c%ndet      = ndet
     c%nscan     = size(ntod_scan)
-    c%ncol      = size(col_def)
     c%ntod      = sum(ntod_scan)
     c%nobs      = size(ind2pix)
+
+    if (c%maptype == 1) then
+       ! Temperature only
+       c%ncol = 1
+    else
+       write(*,*) 'CGmap type not supported = ', maptype
+       stop
+    end if
     
-    allocate(c%col_def(c%ncol))
     allocate(c%ind2pix(c%nobs))
-    c%col_def   = col_def
     c%ind2pix   = ind2pix
     
     ! Find start index for each scan; each scan is stored in (ind_scan(i-1)+1):ind_scan(i)
@@ -113,6 +118,10 @@ contains
     if (c%myid == 0) allocate(c%x(c%ncol,c%npix))
     if (c%myid == 0) allocate(c%invM(c%ncol,c%npix))
     c%accept = .false.
+
+    if (c%maptype > 1) then ! Polarization
+       allocate(c%psi(c%ndet,c%ntod))
+    end if
     
     ! Check for optional matrix operators
     if (present(W_S))  c%W_S  => W_S
@@ -129,10 +138,10 @@ contains
   subroutine dealloc_cgmap(c)
     implicit none
     class(comm_cgmap), pointer, intent(inout) :: c
-    if (allocated(c%col_def))   deallocate(c%col_def)
     if (allocated(c%ind_scan))  deallocate(c%ind_scan)
     if (allocated(c%tod))       deallocate(c%tod)
     if (allocated(c%ind))       deallocate(c%ind)
+    if (allocated(c%psi))       deallocate(c%psi)
     if (allocated(c%mask))      deallocate(c%mask)
     if (allocated(c%invM))      deallocate(c%invM)
     if (allocated(c%x))         deallocate(c%x)
@@ -162,6 +171,10 @@ contains
        self%invN(det,scan)   = 1./(tod%scans(scan)%d(det)%N_psd%sigma0/&
             & tod%scans(scan)%d(det)%gain)**2
     end do
+
+    if (self%maptype > 1) then
+       self%psi(:,i:j) = transpose(sd%psi(:,:,1))
+    end if
     
   end subroutine load_calibrated_data
 
@@ -391,7 +404,9 @@ contains
        j = self%ind_scan(scan)
        do det = 1, self%ndet
           if (.not. self%accept(det,scan)) cycle
-          self%tod(det,i:j) = self%xi(1,self%ind(det,i:j))
+          if (self%maptype == 1) then
+             self%tod(det,i:j) = self%xi(1,self%ind(det,i:j))
+          end if
        end do
     end do
     
@@ -409,7 +424,9 @@ contains
        j = self%ind_scan(scan)
        do det = 1, self%ndet
           if (.not. self%accept(det,scan)) cycle
-          self%xi(1,self%ind(det,i:j)) = self%xi(1,self%ind(det,i:j)) + self%tod(det,i:j)
+          if (self%maptype == 1) then
+             self%xi(1,self%ind(det,i:j)) = self%xi(1,self%ind(det,i:j)) + self%tod(det,i:j)
+          end if
        end do
     end do
     

--- a/commander3/src/comm_tod_cgmap_mod.f90
+++ b/commander3/src/comm_tod_cgmap_mod.f90
@@ -1,0 +1,446 @@
+!================================================================================
+!
+! Copyright (C) 2020 Institute of Theoretical Astrophysics, University of Oslo.
+!
+! This file is part of Commander3.
+!
+! Commander3 is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! Commander3 is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with Commander3. If not, see <https://www.gnu.org/licenses/>.
+!
+!================================================================================
+module comm_tod_cgmap_mod
+  use comm_utils
+  use comm_map_mod
+  use comm_tod_crosstalk_mod
+  use comm_tod_Tbol_mod
+  implicit none
+   
+  type comm_cgmap
+     integer(i4b)  :: comm, myid, nprocs
+     integer(i4b)  :: ndet, ncol, nside, npix, nscan, ntod, nobs
+     integer(i4b),            allocatable, dimension(:)   :: col_def     ! Column Stokes definition; T_full=1, Q_full=2, U_full=3, S_det=det+3, T_det=-det
+     integer(i4b),            allocatable, dimension(:)   :: ind_scan    ! Index range for each scan (0:nscan)
+     real(dp),                allocatable, dimension(:,:) :: x           ! Final full-sky map; only stored by root processor
+     real(dp),                allocatable, dimension(:,:) :: xi          ! Pixel index based mini-map; separate for each core
+     real(sp),                allocatable, dimension(:,:) :: tod         ! Stacked, calibrated and in-painted TOD, (ndet,nscan*ntod)
+     real(sp),                allocatable, dimension(:,:) :: invN        ! 1/sigma**2 per scan, (ndet,nscan)
+     integer(i4b),            allocatable, dimension(:,:) :: ind         ! Stacked pixel index numbers, (ndet,nscan*ntod)
+     integer(i4b),            allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
+     type(comm_crosstalk),                 pointer        :: W_S         ! Signal crosstalk matrix
+     type(comm_crosstalk),                 pointer        :: W_N         ! Noise crosstalk matrix
+     type(Tbol_ptr),          allocatable, dimension(:)   :: T           ! Bolometer transfer function, (ndet)
+     integer(i4b),            allocatable, dimension(:)   :: ind2pix     ! Conversion table from reduced to full pixel index; individual for each processor
+   contains
+     procedure :: load_data => load_calibrated_data
+     procedure :: solve     => solve_cgmap
+     procedure :: A         => multiply_Amat
+     procedure :: compute_rhs
+     procedure :: invM      => apply_precond
+     procedure :: distrib   => distribute_cgmap
+     procedure :: x_bcast
+     procedure :: x_reduce
+     procedure :: P         => apply_P
+     procedure :: Pt        => apply_Pt
+     procedure :: multiply_invN
+     procedure :: convolve_T
+  end type comm_cgmap
+
+  interface comm_cgmap
+     procedure constructor_cgmap
+  end interface comm_cgmap
+    
+contains
+
+  subroutine constructor_cgmap(comm, nside, ndet, ntod_scan, col_def, ind2pix, W_S, W_N, Tbol) result(c)
+    implicit none
+    integer(i4b),                       intent(in) :: comm, nside, ndet
+    integer(i4b),         dimension(:), intent(in) :: ntod_scan
+    integer(i4b),         dimension(:), intent(in) :: col_def
+    integer(i4b),         dimension(:), intent(in) :: ind2pix
+    type(comm_crosstalk), target,       intent(in), optional :: W_S
+    type(comm_crosstalk), target,       intent(in), optional :: W_N
+    type(Tbol_ptr),       dimension(:), intent(in), optional :: Tbol
+    class(comm_cgmap), pointer                  :: c
+
+    integer(i4b) :: i, ierr
+    
+    allocate(c)
+    c%comm      = comm
+    call mpi_comm_rank(comm, c%myid, ierr)
+    call mpi_comm_size(comm, c%nprocs, ierr) 
+    
+    c%nside     = nside
+    c%npix      = 12*c%nside**2
+    c%ndet      = ndet
+    c%nscan     = size(ntod_scan)
+    c%ncol      = size(col_def)
+    c%ntod      = sum(ntod_scan)
+    c%nobs      = size(ind2pix)
+    
+    allocate(c%col_def(c%ncol))
+    allocate(c%ind2pix(c%nobs))
+    c%col_def   = col_def
+    c%ind2pix   = ind2pix
+    
+    ! Find start index for each scan; each scan is stored in (ind_scan(i-1)+1):ind_scan(i)
+    allocate(c%ind_scan(0:c%nscan))
+    c%ind_scan(0) = 0
+    do i = 2, c%nscan
+       c%ind_scan(i) = c%ind_scan(i-1) + ntod_scan(i)
+    end do
+    
+    allocate(c%tod(c%ndet,c%ntod))
+    allocate(c%ind(c%ndet,c%ntod))
+    allocate(c%mask(c%ndet,c%ntod))
+    allocate(c%invN(c%ndet,c%nscan))
+    allocate(c%xi(c%ncol,c%nobs))
+    if (c%myid == 0) allocate(c%x(c%ncol,c%npix))
+
+    ! Check for optional matrix operators
+    if (present(W_S))  c%W_S  => W_S
+    if (present(W_N))  c%W_N  => W_N
+    if (present(Tbol)) then
+       allocate(c%T(c%ndet))
+       do i = 1, c%ndet
+          c%T(i)%p => Tbol(i)%p
+       end do
+    end if
+    
+  end subroutine constructor_cgmap
+
+  subroutine dealloc_cgmap(c)
+    implicit none
+    class(comm_cgmap), pointer, intent(inout) :: c
+    if (allocated(c%col_def))   deallocate(c%col_def)
+    if (allocated(c%ind_scan))  deallocate(c%ind_scan)
+    if (allocated(c%tod))       deallocate(c%tod)
+    if (allocated(c%ind))       deallocate(c%ind)
+    if (allocated(c%mask))      deallocate(c%mask)
+    if (allocated(c%x))         deallocate(c%x)
+    if (allocated(c%xi))        deallocate(c%xi)
+    if (allocated(c%ind2pix))   deallocate(c%ind2pix)
+    deallocate(c)
+  end subroutine dealloc_cgmap
+
+  subroutine load_calibrated_data(self, scan, tod, ind, mask, sigma0)
+    implicit none
+    class(comm_cgmap),                 intent(inout)  :: self
+    integer(i4b),                      intent(in)     :: scan
+    real(sp),          dimension(:,:), intent(in)     :: tod
+    integer(i4b),      dimension(:,:), intent(in)     :: ind
+    integer(i4b),      dimension(:,:), intent(in)     :: mask
+    real(sp),          dimension(:),   intent(in)     :: sigma0
+
+    integer(i4b) :: i, j
+    
+    i = self%ind_scan(scan-1)+1
+    j = self%ind_scan(scan)
+    self%tod(:,i:j)     = tod
+    self%ind(:,i:j)     = ind
+    self%mask(:,i:j)    = mask
+    self%invN(:,scan)  = 1./sigma0**2
+    
+  end subroutine load_calibrated_data
+
+  subroutine solve_cgmap(self)
+    implicit none
+    class(comm_cgmap), intent(inout)              :: self
+
+    integer(i4b) :: i, j, oper, MAXITER=30, ierr
+    real(dp)     :: delta_old, delta_new, delta0, eps, lim_convergence, dq, alpha, beta, t1, t2
+    real(dp), allocatable, dimension(:,:) :: b, invMb, r, d, q, s
+    
+    if (self%myid == 0) then
+
+       ! Allocate temporary arrays
+       allocate(b(self%ncol,self%npix))
+       allocate(invMb(self%ncol,self%npix))
+       allocate(r(self%ncol,self%npix))
+       allocate(d(self%ncol,self%npix))
+       allocate(q(self%ncol,self%npix))
+       allocate(s(self%ncol,self%npix))       
+
+       ! Initialize RHS
+       call self%compute_RHS(b)
+       
+       ! Initialize map
+       self%x  = 0.d0
+       
+       ! Initialize CG variables
+       r  = b 
+       call self%invM(r, d)
+       
+       delta_new = sum(r*d)
+       call self%invM(b, invMb)
+       delta0    = sum(b*invMb)
+       lim_convergence = eps*delta0
+       
+       ! Run CG search
+       do i = 1, MAXITER
+          call wall_time(t1)
+          
+          ! Check convergence
+          if (delta_new < lim_convergence) then
+             call mpi_bcast(0, 1, MPI_INTEGER, 0, self%comm, ierr)  ! Release slaves
+             exit
+          end if
+          
+          call self%A(d, q)
+          dq        = sum(d*q)
+          alpha     = delta_new / dq
+          self%x    = self%x + alpha * d
+          r         = r      - alpha * q
+          call self%invM(r, s)
+          delta_old = delta_new 
+          delta_new = sum(r*s)
+          beta      = delta_new / delta_old
+          d         = s + beta * d       
+          write(*,fmt='(a,i5,a,e13.5,a,e13.5,a,f8.2)') ' |  CG iter. ', i, ' -- res = ', &
+               & min(delta_new,1d30), ', tol = ', real(lim_convergence,sp), &
+               & ', time = ', real(t2-t1,sp)
+       end do
+
+       call wall_time(t2)
+       write(*,fmt='(a,i5,a,e13.5,a,e13.5,a,f8.2)') ' |  Final CG iter ', i, ' -- res = ', &
+            & real(delta_new,sp), ', tol = ', real(lim_convergence,sp)
+
+       deallocate(b, invMb, r, d, q, s)
+    else
+
+       ! Slave processor
+       oper = 1
+       do while (oper > 0)
+          call mpi_bcast(oper, 1, MPI_INTEGER, 0, self%comm, ierr)
+          if (oper == 1) then
+             call self%A
+          else if (oper == 2) then
+             call self%compute_rhs
+          end if
+       end do
+
+    end if
+        
+  end subroutine solve_cgmap
+
+  subroutine multiply_Amat(self, x, Ax)
+    implicit none
+    class(comm_cgmap),                 intent(inout)         :: self
+    real(dp),          dimension(:,:), intent(in),  optional :: x
+    real(dp),          dimension(:,:), intent(out), optional :: Ax
+
+    integer(i4b) :: ierr
+
+    ! Activate slaves
+    if (self%myid == 0) call mpi_bcast(1, 1, MPI_INTEGER, 0, self%comm, ierr)
+
+    ! Distrbute x; stored in self%xi on each core
+    call self%x_bcast(x)
+
+    ! Compute y = P * x, overwrite self%tod
+    call self%P
+
+    ! Compute y = T P * x
+    if (allocated(self%T)) call self%convolve_T(.false.)
+
+    ! Compute y = W_S T P * x
+    if (associated(self%W_S)) call self%W_S%multiply(.false., self%tod)
+    
+    ! Compute y = W_N^t * invN * W_N * d
+    if (associated(self%W_N)) call self%W_N%multiply(.false., self%tod)
+    call self%multiply_invN
+    if (associated(self%W_N)) call self%W_N%multiply(.true., self%tod)
+
+    ! Compute y = W_S^t invN d
+    if (associated(self%W_S)) call self%W_S%multiply(.true., self%tod)
+
+        ! Compute y = T^t W_S^t * invN d
+    if (allocated(self%T)) call self%convolve_T(.true.)
+
+    ! Compute y = P^t invN d
+    call self%Pt
+
+    ! Collect results from all cores; stored in self%x on root
+    call self%x_reduce(Ax)
+    
+  end subroutine multiply_Amat
+
+  ! Compute rhs = P^t T^t W_S^t invN d
+  subroutine compute_RHS(self, b)
+    implicit none
+    class(comm_cgmap),                 intent(inout)           :: self
+    real(dp),          dimension(:,:), intent(inout), optional :: b
+    
+    integer(i4b) ::  ierr
+
+    ! Activate slaves
+    if (self%myid == 0) call mpi_bcast(2, 1, MPI_INTEGER, 0, self%comm, ierr)
+
+    ! Compute y = W_N^t * invN * W_N * d
+    if (associated(self%W_N)) call self%W_N%multiply(.false., self%tod)
+    call self%multiply_invN
+    if (associated(self%W_N)) call self%W_N%multiply(.true., self%tod)
+
+    ! Compute y = W_S^t invN d
+    if (associated(self%W_S)) call self%W_S%multiply(.true., self%tod)
+
+    ! Compute y = T^t W_S^t * invN d
+    if (allocated(self%T)) call self%convolve_T(.true.)
+
+    ! Compute y = P^t invN d
+    call self%Pt
+
+    ! Collect results from all cores
+    call self%x_reduce(b)
+
+  end subroutine compute_RHS
+
+ 
+  subroutine apply_precond(self, x, invMx)
+    implicit none
+    class(comm_cgmap),                 intent(in)  :: self
+    real(dp),          dimension(:,:), intent(in)  :: x
+    real(dp),          dimension(:,:), intent(out) :: invMx
+    invMx = x
+  end subroutine apply_precond
+  
+  subroutine distribute_cgmap(self,  map_out)
+    implicit none
+    class(comm_cgmap), intent(in)    :: self
+    class(comm_map),   intent(inout) :: map_out
+  end subroutine distribute_cgmap
+
+  subroutine multiply_invN(self)
+    implicit none
+    class(comm_cgmap),                 intent(inout)    :: self
+
+    integer(i4b) :: i, j, scan, det
+    
+    do scan = 1, self%nscan
+       i = self%ind_scan(scan-1)+1
+       j = self%ind_scan(scan)
+       do det = 1, self%ndet
+          self%tod(det,i:j) = self%tod(det,i:j) * self%invN(det,scan)
+       end do
+    end do
+    
+  end subroutine multiply_invN
+
+  subroutine apply_P(self)
+    implicit none
+    class(comm_cgmap),                 intent(inout)    :: self
+
+    integer(i4b) :: i, det
+    
+    do i = 1, self%ntod
+       do det = 1, self%ndet
+          self%tod(det,i) = self%xi(1,self%ind(det,i))
+       end do
+    end do
+    
+  end subroutine apply_P
+
+  subroutine apply_Pt(self)
+    implicit none
+    class(comm_cgmap),                 intent(inout) :: self
+
+    integer(i4b) :: i, det
+
+    self%xi = 0.d0
+    do i = 1, self%ntod
+       do det = 1, self%ndet
+          self%xi(1,self%ind(det,i)) = self%xi(1,self%ind(det,i)) + self%tod(det,i)
+       end do
+    end do
+    
+  end subroutine apply_Pt
+
+  subroutine convolve_T(self, trans)
+    implicit none
+    class(comm_cgmap),                 intent(inout) :: self
+    logical(lgt),                      intent(in)    :: trans
+
+    integer(i4b) :: i, j, scan, det   
+
+    do scan = 1, self%nscan
+       i = self%ind_scan(scan-1)+1
+       j = self%ind_scan(scan)
+       do det = 1, self%ndet
+          call self%T(det)%p%convolve(self%tod(det,i:j))
+       end do
+    end do
+
+  end subroutine convolve_T
+
+  subroutine x_bcast(self, x)
+    implicit none
+    class(comm_cgmap),                 intent(inout)           :: self
+    real(dp),          dimension(:,:), intent(in),    optional :: x
+
+    integer(i4b) :: i, j, scan, det, nobs, ierr
+    integer(i4b), allocatable, dimension(:)   :: p
+    real(dp),     allocatable, dimension(:,:) :: buffer
+    integer(i4b), dimension(MPI_STATUS_SIZE)  :: mpistat
+    
+    if (self%myid == 0) then
+       self%xi = x(:,self%ind2pix)
+       do i = 1, self%nprocs-1
+          call mpi_recv(nobs,       1, MPI_INTEGER, i, 98, self%comm, mpistat, ierr)
+          allocate(p(nobs), buffer(self%ncol,nobs))
+          call mpi_recv(p,      nobs, MPI_INTEGER, i, 98, self%comm, mpistat, ierr)
+          buffer = x(:,p)
+          call mpi_send(buffer,      size(buffer), MPI_DOUBLE_PRECISION, i, 98, &
+               & self%comm, ierr)
+          deallocate(p, buffer)
+       end do
+    else
+       call mpi_send(self%nobs,    1,             MPI_INTEGER, 0, 98, self%comm, ierr)
+       call mpi_send(self%ind2pix, self%nobs,     MPI_INTEGER, 0, 98, self%comm, ierr)
+       call mpi_recv(self%xi,      size(self%xi), &
+            & MPI_DOUBLE_PRECISION, 0, 98, self%comm, mpistat, ierr)
+    end if
+
+  end subroutine x_bcast
+
+  subroutine x_reduce(self, x)
+    implicit none
+    class(comm_cgmap),                 intent(in)            :: self
+    real(dp),          dimension(:,:), intent(out), optional :: x
+
+    integer(i4b) :: i, j, scan, det, nobs, ierr
+    integer(i4b), allocatable, dimension(:)   :: p
+    real(dp),     allocatable, dimension(:,:) :: buffer
+    integer(i4b), dimension(MPI_STATUS_SIZE)  :: mpistat
+    
+    if (self%myid == 0) then
+       x                 = 0.d0
+       x(:,self%ind2pix) = self%xi 
+       do i = 1, self%nprocs-1
+          call mpi_recv(nobs,       1, MPI_INTEGER, i, 98, self%comm, mpistat, ierr)
+          allocate(p(nobs), buffer(self%ncol,nobs))
+          call mpi_recv(p,      nobs, MPI_INTEGER, i, 98, self%comm, mpistat, ierr)
+          call mpi_recv(buffer, size(buffer), &
+               & MPI_DOUBLE_PRECISION, i, 98, self%comm, mpistat, ierr)
+          x(:,p) = x(:,p) + buffer
+          deallocate(p, buffer)
+       end do
+    else
+       call mpi_send(self%nobs,    1,             MPI_INTEGER, 0, 98, self%comm, ierr)
+       call mpi_send(self%ind2pix, self%nobs,     MPI_INTEGER, 0, 98, self%comm, ierr)
+       call mpi_send(self%xi,      size(self%xi), MPI_DOUBLE_PRECISION, 0, 98, &
+            & self%comm, ierr)
+    end if
+    
+  end subroutine x_reduce
+
+  
+end module comm_tod_cgmap_mod

--- a/commander3/src/comm_tod_cgmap_mod.f90
+++ b/commander3/src/comm_tod_cgmap_mod.f90
@@ -19,10 +19,10 @@
 !
 !================================================================================
 module comm_tod_cgmap_mod
-  use comm_utils
   use comm_map_mod
-  use comm_tod_crosstalk_mod
+  use comm_tod_mod
   use comm_tod_Tbol_mod
+  use comm_tod_crosstalk_mod
   implicit none
 
   private
@@ -31,6 +31,7 @@ module comm_tod_cgmap_mod
   type comm_cgmap
      integer(i4b)  :: comm, myid, nprocs
      integer(i4b)  :: ndet, ncol, nside, npix, nscan, ntod, nobs
+     logical(lgt),            allocatable, dimension(:,:) :: accept      ! Accept status, (ndet,nscan)
      integer(i4b),            allocatable, dimension(:)   :: col_def     ! Column Stokes definition; T_full=1, Q_full=2, U_full=3, S_det=det+3, T_det=-det
      integer(i4b),            allocatable, dimension(:)   :: ind_scan    ! Index range for each scan (0:nscan)
      real(dp),                allocatable, dimension(:,:) :: x           ! Final full-sky map; only stored by root processor
@@ -39,7 +40,7 @@ module comm_tod_cgmap_mod
      real(sp),                allocatable, dimension(:,:) :: tod         ! Stacked, calibrated and in-painted TOD, (ndet,nscan*ntod)
      real(sp),                allocatable, dimension(:,:) :: invN        ! 1/sigma**2 per scan, (ndet,nscan)
      integer(i4b),            allocatable, dimension(:,:) :: ind         ! Stacked pixel index numbers, (ndet,nscan*ntod)
-     real(sp),                allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
+     integer(i4b),            allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
      type(comm_crosstalk),                 pointer        :: W_S         ! Signal crosstalk matrix
      type(comm_crosstalk),                 pointer        :: W_N         ! Noise crosstalk matrix
      type(Tbol_ptr),          allocatable, dimension(:)   :: T           ! Bolometer transfer function, (ndet)
@@ -50,7 +51,7 @@ module comm_tod_cgmap_mod
      procedure :: A         => multiply_Amat
      procedure :: compute_rhs
      procedure :: apply_precond
-     procedure :: init_invM 
+     procedure :: init_precond
      procedure :: x_bcast
      procedure :: x_reduce
      procedure :: P         => apply_P
@@ -108,9 +109,11 @@ contains
     allocate(c%mask(c%ndet,c%ntod))
     allocate(c%invN(c%ndet,c%nscan))
     allocate(c%xi(c%ncol,c%nobs))
+    allocate(c%accept(c%ndet,c%nscan))
     if (c%myid == 0) allocate(c%x(c%ncol,c%npix))
     if (c%myid == 0) allocate(c%invM(c%ncol,c%npix))
-
+    c%accept = .false.
+    
     ! Check for optional matrix operators
     if (present(W_S))  c%W_S  => W_S
     if (present(W_N))  c%W_N  => W_N
@@ -135,26 +138,30 @@ contains
     if (allocated(c%x))         deallocate(c%x)
     if (allocated(c%xi))        deallocate(c%xi)
     if (allocated(c%ind2pix))   deallocate(c%ind2pix)
+    if (allocated(c%accept))   deallocate(c%accept)
     deallocate(c)
   end subroutine dealloc_cgmap
 
-  subroutine load_calibrated_data(self, scan, tod, ind, mask, sigma0)
+  subroutine load_calibrated_data(self, scan, tod, sd, d_calib)
     implicit none
-    class(comm_cgmap),                 intent(inout)  :: self
-    integer(i4b),                      intent(in)     :: scan
-    real(sp),          dimension(:,:), intent(in)     :: tod
-    integer(i4b),      dimension(:,:), intent(in)     :: ind
-    real(sp),          dimension(:,:), intent(in)     :: mask
-    real(sp),          dimension(:),   intent(in)     :: sigma0
+    class(comm_cgmap),                   intent(inout)  :: self
+    integer(i4b),                        intent(in)     :: scan
+    class(comm_tod),                     intent(in)     :: tod
+    class(comm_scandata),                intent(in)     :: sd
+    real(sp),          dimension(1:,1:), intent(in)     :: d_calib !(ntod, ndet)
 
-    integer(i4b) :: i, j
+    integer(i4b) :: i, j, det
     
     i = self%ind_scan(scan-1)+1
     j = self%ind_scan(scan)
-    self%tod(:,i:j)     = tod
-    self%ind(:,i:j)     = ind
-    self%mask(:,i:j)    = mask
-    self%invN(:,scan)  = 1./sigma0**2
+    self%tod(:,i:j)     = transpose(d_calib)
+    self%ind(:,i:j)     = transpose(sd%ind(:,:,1))
+    self%mask(:,i:j)    = transpose(iand(sd%flag,tod%flag0))
+    do det = 1, self%ndet
+       self%accept(det,scan) = tod%scans(scan)%d(det)%accept
+       self%invN(det,scan)   = 1./(tod%scans(scan)%d(det)%N_psd%sigma0/&
+            & tod%scans(scan)%d(det)%gain)**2
+    end do
     
   end subroutine load_calibrated_data
 
@@ -166,6 +173,9 @@ contains
     integer(i4b) :: i, j, oper, MAXITER=30, ierr
     real(dp)     :: delta_old, delta_new, delta0, eps = 1d-6, lim_convergence, dq, alpha, beta, t1, t2
     real(dp), allocatable, dimension(:,:) :: b, invMb, r, d, q, s
+
+    ! Initialize preconditioner
+    call self%init_precond
     
     if (self%myid == 0) then
 
@@ -322,7 +332,7 @@ contains
     invMx = self%invM * x
   end subroutine apply_precond
 
-  subroutine init_invM(self)
+  subroutine init_precond(self)
     implicit none
     class(comm_cgmap),                 intent(inout)    :: self
 
@@ -331,8 +341,11 @@ contains
     self%xi = 0.d0
     do scan = 1, self%nscan
        do det = 1, self%ndet
+          if (.not. self%accept(det,scan)) cycle
           do t = self%ind_scan(scan-1)+1, self%ind_scan(scan)
-             self%xi(det,self%ind(det,t)) = self%xi(det,self%ind(det,t)) + self%invN(det,scan)
+             if (self%mask(det,t) == 0) then
+                self%xi(1,self%ind(det,t)) = self%xi(1,self%ind(det,t)) + self%invN(det,scan)
+             end if
           end do
        end do
     end do
@@ -344,7 +357,7 @@ contains
        end where
     end if
     
-  end subroutine init_invM
+  end subroutine init_precond
   
   subroutine multiply_invN(self)
     implicit none
@@ -356,7 +369,12 @@ contains
        i = self%ind_scan(scan-1)+1
        j = self%ind_scan(scan)
        do det = 1, self%ndet
-          self%tod(det,i:j) = self%tod(det,i:j) * self%invN(det,scan)
+          if (.not. self%accept(det,scan)) cycle
+          where (self%mask(det,i:j) == 0)
+             self%tod(det,i:j) = self%tod(det,i:j) * self%invN(det,scan)
+          elsewhere
+             self%tod(det,i:j) = 0.  ! Remove flagged samples
+          end where
        end do
     end do
     
@@ -366,11 +384,14 @@ contains
     implicit none
     class(comm_cgmap),                 intent(inout)    :: self
 
-    integer(i4b) :: i, det
+    integer(i4b) :: i, j, det, scan
     
-    do i = 1, self%ntod
+    do scan = 1, self%nscan
+       i = self%ind_scan(scan-1)+1
+       j = self%ind_scan(scan)
        do det = 1, self%ndet
-          self%tod(det,i) = self%xi(1,self%ind(det,i))
+          if (.not. self%accept(det,scan)) cycle
+          self%tod(det,i:j) = self%xi(1,self%ind(det,i:j))
        end do
     end do
     
@@ -380,12 +401,15 @@ contains
     implicit none
     class(comm_cgmap),                 intent(inout) :: self
 
-    integer(i4b) :: i, det
+    integer(i4b) :: i, j, det, scan
 
     self%xi = 0.d0
-    do i = 1, self%ntod
+    do scan = 1, self%nscan
+       i = self%ind_scan(scan-1)+1
+       j = self%ind_scan(scan)
        do det = 1, self%ndet
-          self%xi(1,self%ind(det,i)) = self%xi(1,self%ind(det,i)) + self%tod(det,i)
+          if (.not. self%accept(det,scan)) cycle
+          self%xi(1,self%ind(det,i:j)) = self%xi(1,self%ind(det,i:j)) + self%tod(det,i:j)
        end do
     end do
     
@@ -402,6 +426,7 @@ contains
        i = self%ind_scan(scan-1)+1
        j = self%ind_scan(scan)
        do det = 1, self%ndet
+          if (.not. self%accept(det,scan)) cycle
           call self%T(det)%p%convolve(self%tod(det,i:j))
        end do
     end do
@@ -410,8 +435,8 @@ contains
 
   subroutine x_bcast(self, x)
     implicit none
-    class(comm_cgmap),                   intent(inout) :: self
-    real(dp),          dimension(1:,0:), intent(in)    :: x
+    class(comm_cgmap),                   intent(inout)          :: self
+    real(dp),          dimension(1:,0:), intent(in),   optional :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p
@@ -440,8 +465,8 @@ contains
 
   subroutine x_reduce(self, x)
     implicit none
-    class(comm_cgmap),                   intent(in)  :: self
-    real(dp),          dimension(1:,0:), intent(out) :: x
+    class(comm_cgmap),                   intent(in)            :: self
+    real(dp),          dimension(1:,0:), intent(out), optional :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p

--- a/commander3/src/comm_tod_cgmap_mod.f90
+++ b/commander3/src/comm_tod_cgmap_mod.f90
@@ -24,7 +24,10 @@ module comm_tod_cgmap_mod
   use comm_tod_crosstalk_mod
   use comm_tod_Tbol_mod
   implicit none
-   
+
+  private
+  public comm_cgmap, dealloc_cgmap
+  
   type comm_cgmap
      integer(i4b)  :: comm, myid, nprocs
      integer(i4b)  :: ndet, ncol, nside, npix, nscan, ntod, nobs
@@ -35,7 +38,7 @@ module comm_tod_cgmap_mod
      real(sp),                allocatable, dimension(:,:) :: tod         ! Stacked, calibrated and in-painted TOD, (ndet,nscan*ntod)
      real(sp),                allocatable, dimension(:,:) :: invN        ! 1/sigma**2 per scan, (ndet,nscan)
      integer(i4b),            allocatable, dimension(:,:) :: ind         ! Stacked pixel index numbers, (ndet,nscan*ntod)
-     integer(i4b),            allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
+     real(sp),                allocatable, dimension(:,:) :: mask        ! Stacked TOD processing mask, (ndet,nscan*ntod)
      type(comm_crosstalk),                 pointer        :: W_S         ! Signal crosstalk matrix
      type(comm_crosstalk),                 pointer        :: W_N         ! Noise crosstalk matrix
      type(Tbol_ptr),          allocatable, dimension(:)   :: T           ! Bolometer transfer function, (ndet)
@@ -46,7 +49,6 @@ module comm_tod_cgmap_mod
      procedure :: A         => multiply_Amat
      procedure :: compute_rhs
      procedure :: invM      => apply_precond
-     procedure :: distrib   => distribute_cgmap
      procedure :: x_bcast
      procedure :: x_reduce
      procedure :: P         => apply_P
@@ -61,7 +63,7 @@ module comm_tod_cgmap_mod
     
 contains
 
-  subroutine constructor_cgmap(comm, nside, ndet, ntod_scan, col_def, ind2pix, W_S, W_N, Tbol) result(c)
+  function constructor_cgmap(comm, nside, ndet, ntod_scan, col_def, ind2pix, W_S, W_N, Tbol) result(c)
     implicit none
     integer(i4b),                       intent(in) :: comm, nside, ndet
     integer(i4b),         dimension(:), intent(in) :: ntod_scan
@@ -95,7 +97,7 @@ contains
     ! Find start index for each scan; each scan is stored in (ind_scan(i-1)+1):ind_scan(i)
     allocate(c%ind_scan(0:c%nscan))
     c%ind_scan(0) = 0
-    do i = 2, c%nscan
+    do i = 1, c%nscan
        c%ind_scan(i) = c%ind_scan(i-1) + ntod_scan(i)
     end do
     
@@ -116,7 +118,7 @@ contains
        end do
     end if
     
-  end subroutine constructor_cgmap
+  end function constructor_cgmap
 
   subroutine dealloc_cgmap(c)
     implicit none
@@ -138,7 +140,7 @@ contains
     integer(i4b),                      intent(in)     :: scan
     real(sp),          dimension(:,:), intent(in)     :: tod
     integer(i4b),      dimension(:,:), intent(in)     :: ind
-    integer(i4b),      dimension(:,:), intent(in)     :: mask
+    real(sp),          dimension(:,:), intent(in)     :: mask
     real(sp),          dimension(:),   intent(in)     :: sigma0
 
     integer(i4b) :: i, j
@@ -152,12 +154,13 @@ contains
     
   end subroutine load_calibrated_data
 
-  subroutine solve_cgmap(self)
+  subroutine solve_cgmap(self, map_out)
     implicit none
-    class(comm_cgmap), intent(inout)              :: self
+    class(comm_cgmap), intent(inout) :: self
+    class(comm_map),   intent(inout) :: map_out
 
     integer(i4b) :: i, j, oper, MAXITER=30, ierr
-    real(dp)     :: delta_old, delta_new, delta0, eps, lim_convergence, dq, alpha, beta, t1, t2
+    real(dp)     :: delta_old, delta_new, delta0, eps = 1d-6, lim_convergence, dq, alpha, beta, t1, t2
     real(dp), allocatable, dimension(:,:) :: b, invMb, r, d, q, s
     
     if (self%myid == 0) then
@@ -169,7 +172,7 @@ contains
        allocate(d(self%ncol,self%npix))
        allocate(q(self%ncol,self%npix))
        allocate(s(self%ncol,self%npix))       
-
+       
        ! Initialize RHS
        call self%compute_RHS(b)
        
@@ -190,10 +193,7 @@ contains
           call wall_time(t1)
           
           ! Check convergence
-          if (delta_new < lim_convergence) then
-             call mpi_bcast(0, 1, MPI_INTEGER, 0, self%comm, ierr)  ! Release slaves
-             exit
-          end if
+          if (delta_new < lim_convergence) exit
           
           call self%A(d, q)
           dq        = sum(d*q)
@@ -204,12 +204,15 @@ contains
           delta_old = delta_new 
           delta_new = sum(r*s)
           beta      = delta_new / delta_old
-          d         = s + beta * d       
+          d         = s + beta * d
+
+          call wall_time(t2)
           write(*,fmt='(a,i5,a,e13.5,a,e13.5,a,f8.2)') ' |  CG iter. ', i, ' -- res = ', &
                & min(delta_new,1d30), ', tol = ', real(lim_convergence,sp), &
                & ', time = ', real(t2-t1,sp)
        end do
-
+       call mpi_bcast(0, 1, MPI_INTEGER, 0, self%comm, ierr)  ! Release slaves
+       
        call wall_time(t2)
        write(*,fmt='(a,i5,a,e13.5,a,e13.5,a,f8.2)') ' |  Final CG iter ', i, ' -- res = ', &
             & real(delta_new,sp), ', tol = ', real(lim_convergence,sp)
@@ -229,7 +232,10 @@ contains
        end do
 
     end if
-        
+
+    ! Distribute full-sky map
+    call map_out%bcast_fullsky_from_root(transpose(self%x))
+    
   end subroutine solve_cgmap
 
   subroutine multiply_Amat(self, x, Ax)
@@ -313,12 +319,6 @@ contains
     invMx = x
   end subroutine apply_precond
   
-  subroutine distribute_cgmap(self,  map_out)
-    implicit none
-    class(comm_cgmap), intent(in)    :: self
-    class(comm_map),   intent(inout) :: map_out
-  end subroutine distribute_cgmap
-
   subroutine multiply_invN(self)
     implicit none
     class(comm_cgmap),                 intent(inout)    :: self
@@ -383,8 +383,8 @@ contains
 
   subroutine x_bcast(self, x)
     implicit none
-    class(comm_cgmap),                 intent(inout)           :: self
-    real(dp),          dimension(:,:), intent(in),    optional :: x
+    class(comm_cgmap),                   intent(inout)           :: self
+    real(dp),          dimension(1:,0:), intent(in),    optional :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p
@@ -413,8 +413,8 @@ contains
 
   subroutine x_reduce(self, x)
     implicit none
-    class(comm_cgmap),                 intent(in)            :: self
-    real(dp),          dimension(:,:), intent(out), optional :: x
+    class(comm_cgmap),                   intent(in)            :: self
+    real(dp),          dimension(1:,0:), intent(out), optional :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p

--- a/commander3/src/comm_tod_cgmap_mod.f90
+++ b/commander3/src/comm_tod_cgmap_mod.f90
@@ -34,6 +34,7 @@ module comm_tod_cgmap_mod
      integer(i4b),            allocatable, dimension(:)   :: col_def     ! Column Stokes definition; T_full=1, Q_full=2, U_full=3, S_det=det+3, T_det=-det
      integer(i4b),            allocatable, dimension(:)   :: ind_scan    ! Index range for each scan (0:nscan)
      real(dp),                allocatable, dimension(:,:) :: x           ! Final full-sky map; only stored by root processor
+     real(dp),                allocatable, dimension(:,:) :: invM        ! Diagonal preconditioner
      real(dp),                allocatable, dimension(:,:) :: xi          ! Pixel index based mini-map; separate for each core
      real(sp),                allocatable, dimension(:,:) :: tod         ! Stacked, calibrated and in-painted TOD, (ndet,nscan*ntod)
      real(sp),                allocatable, dimension(:,:) :: invN        ! 1/sigma**2 per scan, (ndet,nscan)
@@ -48,7 +49,8 @@ module comm_tod_cgmap_mod
      procedure :: solve     => solve_cgmap
      procedure :: A         => multiply_Amat
      procedure :: compute_rhs
-     procedure :: invM      => apply_precond
+     procedure :: apply_precond
+     procedure :: init_invM 
      procedure :: x_bcast
      procedure :: x_reduce
      procedure :: P         => apply_P
@@ -107,6 +109,7 @@ contains
     allocate(c%invN(c%ndet,c%nscan))
     allocate(c%xi(c%ncol,c%nobs))
     if (c%myid == 0) allocate(c%x(c%ncol,c%npix))
+    if (c%myid == 0) allocate(c%invM(c%ncol,c%npix))
 
     ! Check for optional matrix operators
     if (present(W_S))  c%W_S  => W_S
@@ -128,6 +131,7 @@ contains
     if (allocated(c%tod))       deallocate(c%tod)
     if (allocated(c%ind))       deallocate(c%ind)
     if (allocated(c%mask))      deallocate(c%mask)
+    if (allocated(c%invM))      deallocate(c%invM)
     if (allocated(c%x))         deallocate(c%x)
     if (allocated(c%xi))        deallocate(c%xi)
     if (allocated(c%ind2pix))   deallocate(c%ind2pix)
@@ -181,10 +185,10 @@ contains
        
        ! Initialize CG variables
        r  = b 
-       call self%invM(r, d)
+       call self%apply_precond(r, d)
        
        delta_new = sum(r*d)
-       call self%invM(b, invMb)
+       call self%apply_precond(b, invMb)
        delta0    = sum(b*invMb)
        lim_convergence = eps*delta0
        
@@ -200,7 +204,7 @@ contains
           alpha     = delta_new / dq
           self%x    = self%x + alpha * d
           r         = r      - alpha * q
-          call self%invM(r, s)
+          call self%apply_precond(r, s)
           delta_old = delta_new 
           delta_new = sum(r*s)
           beta      = delta_new / delta_old
@@ -309,15 +313,38 @@ contains
     call self%x_reduce(b)
 
   end subroutine compute_RHS
-
  
   subroutine apply_precond(self, x, invMx)
     implicit none
     class(comm_cgmap),                 intent(in)  :: self
     real(dp),          dimension(:,:), intent(in)  :: x
     real(dp),          dimension(:,:), intent(out) :: invMx
-    invMx = x
+    invMx = self%invM * x
   end subroutine apply_precond
+
+  subroutine init_invM(self)
+    implicit none
+    class(comm_cgmap),                 intent(inout)    :: self
+
+    integer(i4b) :: i, j, scan, det, t
+
+    self%xi = 0.d0
+    do scan = 1, self%nscan
+       do det = 1, self%ndet
+          do t = self%ind_scan(scan-1)+1, self%ind_scan(scan)
+             self%xi(det,self%ind(det,t)) = self%xi(det,self%ind(det,t)) + self%invN(det,scan)
+          end do
+       end do
+    end do
+
+    call self%x_reduce(self%invM)
+    if (self%myid == 0) then
+       where (self%invM > 0.d0) 
+          self%invM = 1.d0 / self%invM
+       end where
+    end if
+    
+  end subroutine init_invM
   
   subroutine multiply_invN(self)
     implicit none
@@ -383,8 +410,8 @@ contains
 
   subroutine x_bcast(self, x)
     implicit none
-    class(comm_cgmap),                   intent(inout)           :: self
-    real(dp),          dimension(1:,0:), intent(in),    optional :: x
+    class(comm_cgmap),                   intent(inout) :: self
+    real(dp),          dimension(1:,0:), intent(in)    :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p
@@ -413,8 +440,8 @@ contains
 
   subroutine x_reduce(self, x)
     implicit none
-    class(comm_cgmap),                   intent(in)            :: self
-    real(dp),          dimension(1:,0:), intent(out), optional :: x
+    class(comm_cgmap),                   intent(in)  :: self
+    real(dp),          dimension(1:,0:), intent(out) :: x
 
     integer(i4b) :: i, j, scan, det, nobs, ierr
     integer(i4b), allocatable, dimension(:)   :: p

--- a/commander3/src/comm_tod_crosstalk_mod.f90
+++ b/commander3/src/comm_tod_crosstalk_mod.f90
@@ -149,9 +149,10 @@ contains
   end subroutine remove_crosstalk_signal
 
   ! Routine for multiplying multi-component TOD (ntod x ndet) with crosstalk matrix
-  subroutine multiply_crosstalk_matrix(self, tod)
+  subroutine multiply_crosstalk_matrix(self, transpose, tod)
     implicit none
     class(comm_crosstalk),                 intent(in)    :: self
+    logical(lgt),                          intent(in)    :: transpose
     real(sp),              dimension(:,:), intent(inout) :: tod
   end subroutine multiply_crosstalk_matrix
 

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -80,7 +80,7 @@ contains
     if (btest(oper,SD_TOD))     allocate(sd%tod     (ntod, ndet))
     if (btest(oper,SD_ORB))     allocate(sd%s_orb   (ntod, ndet, 0:hmax))
     if (btest(oper,SD_SL))      allocate(sd%s_sl    (ntod, ndet, 0:hmax))
-    if (btest(oper,SD_ZODI))    allocate(sd%s_zodi  (ntod, ndet, 0:hmax))
+    if (btest(oper,SD_ZODI) .and. tod%subtract_zodi)    allocate(sd%s_zodi  (ntod, ndet, 0:hmax))
     if (btest(oper,SD_OBJCTR))  allocate(sd%s_objctr(ntod, ndet, 0:hmax))
     if (btest(oper,SD_SKY))     allocate(sd%s_sky   (ntod, ndet, 0:hmax, nbp))
     if (btest(oper,SD_BP))      allocate(sd%s_bp    (ntod, ndet, 0:hmax, nbp))
@@ -196,7 +196,7 @@ contains
     end if
 
     ! Construct zodical light template
-    if (btest(oper,SD_ZODI)) then
+    if (btest(oper,SD_ZODI) .and. tod%subtract_zodi) then
        call timer%start(TOD_ZODI, tod%band)
        call compute_zodi(zodi_model, tod, sd, det)
        call timer%stop(TOD_ZODI, tod%band)
@@ -253,7 +253,7 @@ contains
           do k = 1, nbp
              if (btest(oper,SD_SL))     sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_sl(:,d,:)
              if (btest(oper,SD_ORB))    sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_orb(:,d,:)
-             if (btest(oper,SD_ZODI))   sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_zodi(:,d,:)
+             if (allocated(sd%s_zodi))   sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_zodi(:,d,:)
              if (btest(oper,SD_OBJCTR)) sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_objctr(:,d,:)
           end do
        end do

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -39,17 +39,22 @@ contains
   !                   (1) = demodulate
   !                   (2) = (1) + adc corrections
   !                   (3) = (2) + fill gaps + rolloff deconvolution
-  subroutine init_scan_data(tod, scan, oper, bitmask0, sd, det, nonlin_level, handle)
+  !
+  ! spurious levels   (0) = skip
+  !                   (1) = monopole
+  !                   (2) = (1) + jumps
+  !                   (3) = (2) + instrument-specific
+  subroutine init_scan_data(tod, scan, oper, bitmask0, sd, det, nonlin_level, spur_level, handle)
     implicit none
     class(comm_tod),      intent(inout)           :: tod
     integer(i4b),         intent(in)              :: scan, oper, bitmask0
     class(comm_scandata), intent(inout)           :: sd    
     integer(i4b),         intent(in),    optional :: det
-    integer(i4b),         intent(in),    optional :: nonlin_level 
+    integer(i4b),         intent(in),    optional :: nonlin_level
+    integer(i4b),         intent(in),    optional :: spur_level 
     type(planck_rng),     intent(inout), optional :: handle
 
-
-    integer(i4b) :: i, j, k, d, ntod, hmax, ndet, nhorn, nbp, nonlin_lvl
+    integer(i4b) :: i, j, k, d, ntod, hmax, ndet, nhorn, nbp, nonlin_lvl, spur_lvl
 
     call timer%start(TOD_ALLOC, tod%band)
 
@@ -64,6 +69,7 @@ contains
          & sd%nbp = size(tod%pixcache%map_sky,4)
     sd%hmax     = 0; if (tod%nhorn > 1) sd%hmax = tod%nhorn
     nonlin_lvl  = 100; if (present(nonlin_level)) nonlin_lvl = nonlin_level
+    spur_lvl    = 100; if (present(spur_level))   spur_lvl = spur_level
     
     ! Allocate data structures
     ntod  = sd%ntod
@@ -236,7 +242,7 @@ contains
     end if
     
 
-    ! Generate and apply instrument-specific correction template
+    ! Generate instrument-specific correction template
     if (btest(oper,SD_INST)) then
        call timer%start(TOD_INSTCORR, tod%band)
        call tod%construct_corrtemp_inst(sd, det)
@@ -253,7 +259,7 @@ contains
           do k = 1, nbp
              if (btest(oper,SD_SL))     sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_sl(:,d,:)
              if (btest(oper,SD_ORB))    sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_orb(:,d,:)
-             if (allocated(sd%s_zodi))   sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_zodi(:,d,:)
+             if (allocated(sd%s_zodi))  sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_zodi(:,d,:)
              if (btest(oper,SD_OBJCTR)) sd%s_tot(:,d,:,k) = sd%s_tot(:,d,:,k) + sd%s_objctr(:,d,:)
           end do
        end do
@@ -262,7 +268,7 @@ contains
     ! Coadd horn signals into detector signals; store result in 0th horn-row
     if (nhorn > 1) call tod%coadd_horns(sd)
 
-    ! Add non-optical components into a net spurious component
+    ! Add non-optical components into a net spurious component; subtract from data
     if (btest(oper,SD_SPUR)) then
        sd%s_spur = 0.
        do j = 1, ndet
@@ -272,8 +278,17 @@ contains
           if (btest(oper,SD_JUMP))  sd%s_spur(:,d) = sd%s_spur(:,d) + sd%s_jump(:,d)
           if (btest(oper,SD_INST))  sd%s_spur(:,d) = sd%s_spur(:,d) + sd%s_inst(:,d)
        end do
-    end if
 
+       ! Subtract spurious corrections from TOD according to spur_level
+       do j = 1, ndet
+          d = j; if (present(det)) d = det
+          if (.not. tod%scans(scan)%d(d)%accept) cycle
+          if (spur_lvl > 0 .and. btest(oper,SD_MONO)) sd%tod(:,d) = sd%tod(:,d) - sd%s_mono(:,d)
+          if (spur_lvl > 1 .and. btest(oper,SD_JUMP)) sd%tod(:,d) = sd%tod(:,d) - sd%s_jump(:,d)
+          if (spur_lvl > 2 .and. btest(oper,SD_INST)) sd%tod(:,d) = sd%tod(:,d) - sd%s_inst(:,d)
+       end do
+    end if
+    
   end subroutine init_scan_data
   
   subroutine dealloc_scan_data(sd)

--- a/commander3/src/comm_tod_lfi_smod.f90
+++ b/commander3/src/comm_tod_lfi_smod.f90
@@ -1371,7 +1371,7 @@ contains
        do k = 1, self%scans(scan)%ntod
           t = modulo(self%scans(scan)%t0(2)/65536.d0 + (k-1)*dt,t_tot)    ! OBT is stored in units of 2**-16 = 1/65536 sec
           b = min(int(t*nbin),nbin-1)
-          sd%s_inst(k,l) = self%spike_amplitude(scan,j) * self%spike_templates(b,j)
+          sd%s_inst(k,j) = self%spike_amplitude(scan,j) * self%spike_templates(b,j)
        end do
     end do
 

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -585,8 +585,12 @@ contains
  
     if (cpar%include_tod_zodi) then
       self%subtract_zodi = cpar%ds_tod_subtract_zodi(self%band)
-      self%zodi_n_comps = cpar%zs_ncomps
-      self%sample_zodi = cpar%sample_zodi .and. self%subtract_zodi
+      self%zodi_n_comps  = cpar%zs_ncomps
+      self%sample_zodi   = cpar%sample_zodi .and. self%subtract_zodi
+   else
+      self%subtract_zodi = .false.
+      self%zodi_n_comps  = 0
+      self%sample_zodi   = .false.
    end if
    self%use_solar_point = self%subtract_zodi
    self%use_moon_point  = .false.


### PR DESCRIPTION
This pull request implements support for CG mapmaking, and introduces a new crosstalk_mod. The ultimate goal is to sample maps for the data model:

d = W_s * T * P * s + n

with a CG solver. For now, only T-only mapmaking is supported, but generalizing to polarization (maptype =2), N+2 mapmaking (maptype =  3) or other formats should be straightforward through the pointing operators, P and Pt

This pull request also prepares for instrument corrections for AKARI.