### PR TITLE
Changed ncorr mask temporarily to gain mask

### DIFF
--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -358,7 +358,8 @@ contains
          !write(*,*) i, self%scans(i)%d%accept
          if (.not. any(self%scans(i)%d%accept)) cycle
          call wall_time(t1)
-         call init_scan_data(self, i, oper_default, TODMASK_NCORR, sd)
+         ! FIXME!! NCORR MASK CHANGED TEMPORARILY TO GAIN MASK. WILL LEAK SIGNAL INTO NCORR!!!
+         call init_scan_data(self, i, oper_default, TODMASK_GAIN, sd)
 
           !if (self%myid == 0 .and. i == 1) then
          !    open(58,file='tod.dat', recl=1024)


### PR DESCRIPTION
Changed temporarily Ncorr mask in comm_tod_akari_mod to gain mask. With the current broad ncorr mask, we have scans that have no un-flagged samples outside the ncorr processing mask, and these scans have therefore no baseline correction, but are dumped raw into the final map. The negative thing is that a small ncorr mask will leak Galactic signal into ncorr if there are gain or signal mismatch errors. Down the line, the ncorr masks should be tuned properly, and this change should be reverted. However, this can wait until we got proper compsep up and running.