### PR TITLE
Akari 2oof noise psd

### DIFF
--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -81,8 +81,8 @@ contains
          c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
          c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee
          c%xi_n_P_uni(3,:)  = [-4d0, -0.5d0]   ! Uniform prior for alpha
-         c%xi_n_P_uni(3,:)  = [4.0d0, 1.d1]   ! Uniform prior for fknee2
-         c%xi_n_P_uni(3,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
+         c%xi_n_P_uni(4,:)  = [4.0d0, 1.d1]   ! Uniform prior for fknee2
+         c%xi_n_P_uni(5,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
 
          ! Data selection parameters
          c%chisq_threshold  = 1000d0       ! Cut scans with higher chisq

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -61,8 +61,8 @@ contains
 
       ! Set up noise PSD type and priors
       c%freq            = cpar%ds_label(id_abs)
-      c%n_xi            = 3
-      c%noise_psd_model = 'oof'
+      c%n_xi            = 5
+      c%noise_psd_model = '2oof'
       allocate(c%xi_n_nu_fit(c%n_xi,2))
       allocate(c%xi_n_P_uni(c%n_xi,2))
       allocate(c%xi_n_P_rms(c%n_xi))
@@ -72,10 +72,17 @@ contains
          c%xi_n_nu_fit(1,:) = [0.d0, 1.0d0] ! Freq range for sigma0
          c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0] ! Freq range for fknee
          c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0] ! Freq range for alpha
-         c%xi_n_P_rms       = [-100.d0, -0.01d0, 0.05d0] ! Prior rms [sigma0, fknee, alpha]
+         c%xi_n_nu_fit(4,:) = [4.d0, 1.0d1] ! Freq range for fknee2
+         c%xi_n_nu_fit(5,:) = [4.d0, 1.0d1] ! Freq range for alpha2
+         
+         ! Set rms of all parameters to 0.05 for initial test phase. 
+         c%xi_n_P_rms       = [-100.d0, 0.05d0, 0.05d0, 0.05d0, 0.05d0] ! Prior rms [sigma0, fknee, alpha, fknee2, alpha2]
+
          c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
          c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee
          c%xi_n_P_uni(3,:)  = [-4d0, -0.5d0]   ! Uniform prior for alpha
+         c%xi_n_P_uni(3,:)  = [4.0d0, 1.d1]   ! Uniform prior for fknee2
+         c%xi_n_P_uni(3,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
 
          ! Data selection parameters
          c%chisq_threshold  = 1000d0       ! Cut scans with higher chisq

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -69,14 +69,14 @@ contains
 
       if (.true.) then
          ! Correlated noise parameters
-         c%xi_n_nu_fit(1,:) = [0.d0, 1.0d0] ! Freq range for sigma0
+         c%xi_n_nu_fit(1,:) = [0.05d0, 1.d1] ! Freq range for sigma0
          c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0] ! Freq range for fknee
          c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0] ! Freq range for alpha
          c%xi_n_nu_fit(4,:) = [4.d0, 1.0d1] ! Freq range for fknee2
          c%xi_n_nu_fit(5,:) = [4.d0, 1.0d1] ! Freq range for alpha2
          
          ! Set rms of all parameters to 0.05 for initial test phase. 
-         c%xi_n_P_rms       = [-100.d0, 0.05d0, 0.05d0, 0.05d0, 0.05d0] ! Prior rms [sigma0, fknee, alpha, fknee2, alpha2]
+         c%xi_n_P_rms       = [0.05d0, 0.05d0, 0.05d0, 0.05d0, 0.05d0] ! Prior rms [sigma0, fknee, alpha, fknee2, alpha2]
 
          c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
          c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee

--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -61,28 +61,45 @@ contains
 
       ! Set up noise PSD type and priors
       c%freq            = cpar%ds_label(id_abs)
-      c%n_xi            = 5
       c%noise_psd_model = '2oof'
+
+      if (trim(c%noise_psd_model) == 'oof') then
+         c%n_xi            = 3
+      else if (trim(c%noise_psd_model) == '2oof') then
+         c%n_xi            = 5
+      end if 
+
       allocate(c%xi_n_nu_fit(c%n_xi,2))
       allocate(c%xi_n_P_uni(c%n_xi,2))
       allocate(c%xi_n_P_rms(c%n_xi))
 
       if (.true.) then
          ! Correlated noise parameters
-         c%xi_n_nu_fit(1,:) = [0.05d0, 1.d1] ! Freq range for sigma0
-         c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0] ! Freq range for fknee
-         c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0] ! Freq range for alpha
-         c%xi_n_nu_fit(4,:) = [4.d0, 1.0d1] ! Freq range for fknee2
-         c%xi_n_nu_fit(5,:) = [4.d0, 1.0d1] ! Freq range for alpha2
+         c%xi_n_nu_fit(1,:) = [0.05d0, 1.d1]   ! Freq range for sigma0
+         c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0]    ! Freq range for fknee
+         c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0]    ! Freq range for alpha
          
-         ! Set rms of all parameters to 0.05 for initial test phase. 
-         c%xi_n_P_rms       = [0.05d0, 0.05d0, 0.05d0, 0.05d0, 0.05d0] ! Prior rms [sigma0, fknee, alpha, fknee2, alpha2]
-
          c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
          c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee
          c%xi_n_P_uni(3,:)  = [-4d0, -0.5d0]   ! Uniform prior for alpha
-         c%xi_n_P_uni(4,:)  = [4.0d0, 1.d1]   ! Uniform prior for fknee2
-         c%xi_n_P_uni(5,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
+         
+         ! Set rms of all parameters to 0.05 for initial test phase. 
+         c%xi_n_P_rms(1)    = 0.05d0           ! Prior rms for sigma0
+         c%xi_n_P_rms(2)    = 0.05d0           ! Prior rms for fknee
+         c%xi_n_P_rms(3)    = 0.05d0           ! Prior rms for alpha
+
+         if (trim(c%noise_psd_model) == '2oof') then
+            ! Extend correlated noise parameters for fknee2 and alpha2
+            
+            c%xi_n_nu_fit(4,:) = [4.d0, 1.0d1]  ! Freq range for fknee2
+            c%xi_n_nu_fit(5,:) = [4.d0, 1.0d1]  ! Freq range for alpha2
+            
+            c%xi_n_P_uni(4,:)  = [4.0d0, 1.d1]  ! Uniform prior for fknee2
+            c%xi_n_P_uni(5,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
+            
+            c%xi_n_P_rms(4)    = 0.05d0         ! Prior rms for fknee2
+            c%xi_n_P_rms(5)    = 0.05d0         ! Prior rms for alpha2
+         end if 
 
          ! Data selection parameters
          c%chisq_threshold  = 1000d0       ! Cut scans with higher chisq

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -1288,8 +1288,8 @@ contains
           self%d(i)%N_psd => comm_noise_psd_oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == '2oof') then
           xi_n(1) =  0.10  ! sigma0. Using same as for oof.
-          xi_n(2) =  0.02  ! fknee2 (Hz); arbitrary value
-          xi_n(3) = -2.00  ! alpha2; arbitrary value
+          xi_n(2) =  0.02  ! fknee (Hz); arbitrary value
+          xi_n(3) = -2.00  ! alpha; arbitrary value
           xi_n(4) =  1.00  ! fknee2 (Hz); arbitrary value
           xi_n(5) =  1.00  ! alpha2; arbitrary value >0 for Akari
           self%d(i)%N_psd => comm_noise_psd_2oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -1282,15 +1282,16 @@ contains
        if (trim(tod%noise_psd_model) == 'white') then
           self%d(i)%N_psd => comm_noise_psd_white(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == 'oof') then
-          xi_n(1) =  0.1 ! AKARI
-          xi_n(2) =  0.02 ! AKARI
-          xi_n(3) = -2.00 ! AKARI
+          xi_n(1) =  0.10 ! (Old) AKARI
+          xi_n(2) =  0.02 ! (Old) AKARI
+          xi_n(3) = -2.00 ! (Old) AKARI
           self%d(i)%N_psd => comm_noise_psd_oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == '2oof') then
-          xi_n(2) =  0.2  ! fknee2 (Hz); arbitrary value
-          xi_n(3) = -2.000 ! alpha2; arbitrary value
-          xi_n(4) =  1.  ! fknee2 (Hz); arbitrary value
-          xi_n(5) = -1.000 ! alpha2; arbitrary value
+          ! xi_n(1) = 0.10 ! sigma0. Not sure if we should use initial guess for this?? 
+          xi_n(2) =  0.02  ! fknee2 (Hz); arbitrary value
+          xi_n(3) = -2.00  ! alpha2; arbitrary value
+          xi_n(4) =  1.00  ! fknee2 (Hz); arbitrary value
+          xi_n(5) =  1.00  ! alpha2; arbitrary value >0 for Akari
           self%d(i)%N_psd => comm_noise_psd_2oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == 'oof_gauss') then
           xi_n(4) =  0.00d0

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -1287,7 +1287,7 @@ contains
           xi_n(3) = -2.00 ! (Old) AKARI
           self%d(i)%N_psd => comm_noise_psd_oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == '2oof') then
-          ! xi_n(1) = 0.10 ! sigma0. Not sure if we should use initial guess for this?? 
+          xi_n(1) =  0.10  ! sigma0. Using same as for oof.
           xi_n(2) =  0.02  ! fknee2 (Hz); arbitrary value
           xi_n(3) = -2.00  ! alpha2; arbitrary value
           xi_n(4) =  1.00  ! fknee2 (Hz); arbitrary value


### PR DESCRIPTION
Use a 2oof model for sampling noise psd.

Enables fitting the bump of the psd towards high frequencies.
Sampling of sigma0 and fknee is now _turned on_.

In `comm_tod_akari_smod.f90` the exact values of `xi_n_nu_fit`, `xi_n_P_rms` and `xi_n_P_uni` will likely be refined when the lower level issues have been sorted out. 
Currently, these three values are identical for every band.