### PR TITLE
Akari 2oof freq lims

### DIFF
--- a/commander3/src/comm_tod_akari_smod.f90
+++ b/commander3/src/comm_tod_akari_smod.f90
@@ -53,6 +53,7 @@ contains
 
       integer(i4b) :: i, j, nside_beam, lmax_beam, nmaps_beam, ierr
       logical(lgt) :: pol_beam
+      real(dp)     :: band_samprate
 
       call timer%start(TOD_INIT, id_abs)
 
@@ -72,43 +73,48 @@ contains
       allocate(c%xi_n_nu_fit(c%n_xi,2))
       allocate(c%xi_n_P_uni(c%n_xi,2))
       allocate(c%xi_n_P_rms(c%n_xi))
-
-      if (.true.) then
-         ! Correlated noise parameters
-         c%xi_n_nu_fit(1,:) = [0.05d0, 1.d1]   ! Freq range for sigma0
-         c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0]    ! Freq range for fknee
-         c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0]    ! Freq range for alpha
-         
-         c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
-         c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee
-         c%xi_n_P_uni(3,:)  = [-4d0, -0.5d0]   ! Uniform prior for alpha
-         
-         ! Set rms of all parameters to 0.05 for initial test phase. 
-         c%xi_n_P_rms(1)    = 0.05d0           ! Prior rms for sigma0
-         c%xi_n_P_rms(2)    = 0.05d0           ! Prior rms for fknee
-         c%xi_n_P_rms(3)    = 0.05d0           ! Prior rms for alpha
-
-         if (trim(c%noise_psd_model) == '2oof') then
-            ! Extend correlated noise parameters for fknee2 and alpha2
-            
-            c%xi_n_nu_fit(4,:) = [4.d0, 1.0d1]  ! Freq range for fknee2
-            c%xi_n_nu_fit(5,:) = [4.d0, 1.0d1]  ! Freq range for alpha2
-            
-            c%xi_n_P_uni(4,:)  = [4.0d0, 1.d1]  ! Uniform prior for fknee2
-            c%xi_n_P_uni(5,:)  = [1d-6, 3.d0]   ! Uniform prior for alpha2
-            
-            c%xi_n_P_rms(4)    = 0.05d0         ! Prior rms for fknee2
-            c%xi_n_P_rms(5)    = 0.05d0         ! Prior rms for alpha2
-         end if 
-
-         ! Data selection parameters
-         c%chisq_threshold  = 1000d0       ! Cut scans with higher chisq
-         c%sigma0_threshold = 1.d0        ! Cut scans with higher sigma0
-      else if (trim(c%freq) == 'AKARI_N160') then
+      
+      ! For 2oof, the max psd freq. (samprate/2) is needed for freq. ranges and priors.
+      ! samprate is defined in c%read_tod(c%label), but psd params must be defined before this. 
+      if (trim(c%freq) == 'AKARI_N160') then
+         band_samprate = 16.86
       else if (trim(c%freq) == 'AKARI_WIDE-L') then
+         band_samprate = 16.86
       else if (trim(c%freq) == 'AKARI_WIDE-S') then
+         band_samprate = 25.28
       else if (trim(c%freq) == 'AKARI_N60') then
+         band_samprate = 25.28
       end if
+
+      ! Correlated noise parameters
+      c%xi_n_nu_fit(1,:) = [0.05d0, 1.d1]   ! Freq range for sigma0
+      c%xi_n_nu_fit(2,:) = [0.d0, 0.5d0]    ! Freq range for fknee
+      c%xi_n_nu_fit(3,:) = [0.d0, 0.5d0]    ! Freq range for alpha
+      
+      c%xi_n_P_uni(1,:)  = [1d-6, 1.d0]     ! Uniform prior for sigma0
+      c%xi_n_P_uni(2,:)  = [6d-5, 1.d0]     ! Uniform prior for fknee
+      c%xi_n_P_uni(3,:)  = [-4d0, -0.5d0]   ! Uniform prior for alpha
+      
+      ! Set rms of all parameters to 0.05 for initial test phase. 
+      c%xi_n_P_rms(1)    = 0.05d0           ! Prior rms for sigma0
+      c%xi_n_P_rms(2)    = 0.05d0           ! Prior rms for fknee
+      c%xi_n_P_rms(3)    = 0.05d0           ! Prior rms for alpha
+
+      if (trim(c%noise_psd_model) == '2oof') then
+         ! Extend correlated noise parameters for fknee2 and alpha2
+         c%xi_n_nu_fit(4,:) = [4.d0, band_samprate/2]  ! Freq range for fknee2
+         c%xi_n_nu_fit(5,:) = [4.d0, band_samprate/2]  ! Freq range for alpha2
+         
+         c%xi_n_P_uni(4,:)  = [4.0d0, band_samprate/2]  ! Uniform prior for fknee2
+         c%xi_n_P_uni(5,:)  = [0.5d0, 3.d0]   ! Uniform prior for alpha2
+         
+         c%xi_n_P_rms(4)    = 0.05d0         ! Prior rms for fknee2
+         c%xi_n_P_rms(5)    = 0.05d0         ! Prior rms for alpha2
+      end if
+
+      ! Data selection parameters
+      c%chisq_threshold  = 1000d0       ! Cut scans with higher chisq
+      c%sigma0_threshold = 1.d0        ! Cut scans with higher sigma0
 
       ! Initialize common parameters
       call c%tod_constructor(cpar, id, id_abs, info, tod_type)

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -1290,7 +1290,7 @@ contains
           xi_n(1) =  0.10  ! sigma0. Using same as for oof.
           xi_n(2) =  0.02  ! fknee (Hz); arbitrary value
           xi_n(3) = -2.00  ! alpha; arbitrary value
-          xi_n(4) =  1.00  ! fknee2 (Hz); arbitrary value
+          xi_n(4) =  5.00  ! fknee2 (Hz); arbitrary value
           xi_n(5) =  1.00  ! alpha2; arbitrary value >0 for Akari
           self%d(i)%N_psd => comm_noise_psd_2oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
        else if (trim(tod%noise_psd_model) == 'oof_gauss') then


### PR DESCRIPTION
### Description
For 2oof psd model, the maximum frequency for each band is set as the upper freq. limit for fknee2 and alpha2, and the prior maximum of fknee2. Previously, this was manually set to a single number for all bands. 

Also updated bad choice for initial guess for fknee2.

#### Comments
The maximum freq. is half the sampling rate for a given band, and the sample rates are now defined manually.
This is because the sampling rate is defined when the subroutine `read_tod` of `comm_tod_mod.f90` is called, but the psd parameters must be set up _before_ this subroutine is called. 
Defining the sampling rate manually in `constructor_akari` bypasses this circular dependence problem.   

The implementation is tested, and works for both `c%noise_psd_model = '2oof' `and `c%noise_psd_model = 'oof'`.