### PR TITLE
Ephemeris generator

### DIFF
--- a/commander3/todscripts/AKARI/ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/ephemeris_generator.py
@@ -8,26 +8,42 @@ import tqdm
 import h5py
 import numpy as np
 import astropy.units as u
-from astropy.coordinates import HeliocentricMeanEcliptic, get_body, get_body_barycentric, solar_system_ephemeris, SkyCoord
+from astropy.coordinates import (
+    HeliocentricMeanEcliptic,
+    get_body,
+    get_body_barycentric,
+    solar_system_ephemeris,
+    SkyCoord,
+)
 from astroquery.jplhorizons import Horizons
 from astropy.time import Time
 
 warnings.filterwarnings("ignore")
 
+
 @dataclass
 class CelestialBody:
     """Data class for celestial body data."""
+
     name: str
     time: np.ndarray
     position: np.ndarray
 
+
 class EphemerisGenerator:
-    def __init__(self, 
-                body_names: list[str], 
-                start_time: Optional[u.quantity.Quantity] = Time("1980-01-01 00:00:00.000", format='iso', scale='utc').mjd * u.day, 
-                end_time: Optional[u.quantity.Quantity] = Time("2049-12-31 23:59:59.999", format='iso', scale='utc').mjd * u.day, 
-                time_step: Optional[u.quantity.Quantity] = 3600 * u.s
-        ) -> None:
+    def __init__(
+        self,
+        body_names: list[str],
+        start_time: Optional[u.quantity.Quantity] = Time(
+            "1980-01-01 00:00:00.000", format="iso", scale="utc"
+        ).mjd
+        * u.day,
+        end_time: Optional[u.quantity.Quantity] = Time(
+            "2049-12-31 23:59:59.999", format="iso", scale="utc"
+        ).mjd
+        * u.day,
+        time_step: Optional[u.quantity.Quantity] = 3600 * u.s,
+    ) -> None:
         """Initialize ephemeris generation parameters and time grid.
 
         Parameters
@@ -45,16 +61,28 @@ class EphemerisGenerator:
         self.start_time = start_time
         self.end_time = end_time
         self.time_step = time_step
-        self.time_arr = (Time(self.start_time, format='mjd', scale='utc') 
-                            + np.arange(0, (self.end_time - self.start_time).to(u.min).value, 
-                                        int(np.round(self.time_step.to(u.min).value))) * u.min)
-        
-        
-        self.jpl_horizons_query_limit = 90024
+        self.time_arr = (
+            Time(self.start_time, format="mjd", scale="tai")
+            + np.arange(
+                0,
+                (self.end_time - self.start_time).to(u.min).value,
+                int(np.round(self.time_step.to(u.min).value)),
+            )
+            * u.min
+        )
 
-        # if self.time_arr.size > self.jpl_horizons_query_limit:
-        #     raise ValueError(f"Too many time steps ({self.time_arr.size}) for JPL Horizons, maximum is {self.jpl_horizons_query_limit}. Reduce the number of steps by increasing the time step or reducing the time range.")
-    
+        self.jpl_horizons_query_limit = 90024
+        self.number_of_query_batches = int(
+            np.ceil(self.time_arr.size / self.jpl_horizons_query_limit)
+        )
+        self.batch_size = int(
+            np.ceil(self.time_arr.size / self.number_of_query_batches)
+        )
+
+        print(
+            f"\nTotal time steps: {self.time_arr.size}, which will require {self.number_of_query_batches} batch(es) of queries to JPL Horizons."
+        )
+
     def define_bodies(self, time_arrs: Optional[list[Time]] = None) -> None:
         """Create internal `CelestialBody` entries with associated time arrays.
 
@@ -64,22 +92,50 @@ class EphemerisGenerator:
             Optional list of time arrays to assign per body. If None, uses the
             generator-wide `self.time_arr` for all bodies.
         """
-        
+
         self.bodies = []
 
         print("Defining celestial bodies and associated time arrays...")
         if time_arrs is not None:
             for body, time_arr in zip(self.body_names, time_arrs):
-                self.bodies.append(CelestialBody(name=body, time=time_arr, position=None))
+                self.bodies.append(
+                    CelestialBody(name=body, time=time_arr, position=None)
+                )
         else:
             for body in self.body_names:
-                self.bodies.append(CelestialBody(name=body, time=self.time_arr, position=None))
+                self.bodies.append(
+                    CelestialBody(name=body, time=self.time_arr, position=None)
+                )
 
     def _define_major_and_minor_bodies(self):
-        major_bodies = {"sun": 10, "moon": 301, "mercury": 199, "venus": 299, "earth": 399, "mars": 499, "jupiter": 599, "saturn": 699, "uranus": 799, "neptune": 899, "pluto": 999}
+        """Build lookup tables for major and minor body identifiers.
+
+        Returns
+        -------
+        major_bodies : dict
+            Mapping of major body names (casefolded) to their JPL IDs.
+        minor_bodies : dict
+            Mapping of minor body names (casefolded) to their identifiers as
+            defined in the asteroid orbital elements file.
+        """
+        major_bodies = {
+            "sun": 10,
+            "moon": 301,
+            "mercury": 199,
+            "venus": 299,
+            "earth": 399,
+            "mars": 499,
+            "jupiter": 599,
+            "saturn": 699,
+            "uranus": 799,
+            "neptune": 899,
+            "pluto": 999,
+        }
 
         orbital_element_path = "/mn/stornext/d23/cmbco/globe/common/aux/"
-        path2asteroid_def = os.path.join(orbital_element_path, "asteroid_orbital_elements.txt")
+        path2asteroid_def = os.path.join(
+            orbital_element_path, "asteroid_orbital_elements.txt"
+        )
 
         minor_bodies = {}
         with open(path2asteroid_def, "r") as f:
@@ -87,15 +143,16 @@ class EphemerisGenerator:
             column_widths = []
             for column in asteroid_lines[1].split():
                 column_widths.append(len(column))
-            number_of_columns = len(column_widths)
             for line in asteroid_lines[2:]:
                 previous_width = 0
                 columns = []
-                for i, width in enumerate(column_widths):
-                    columns.append(line[previous_width:previous_width+width + 1].strip())
+                for width in column_widths:
+                    columns.append(
+                        line[previous_width : previous_width + width + 1].strip()
+                    )
                     previous_width = previous_width + width + 1
                 minor_bodies[columns[1].casefold()] = columns[0]
-        
+
         return major_bodies, minor_bodies
 
     def generate_ephemeris(self):
@@ -104,38 +161,88 @@ class EphemerisGenerator:
 
         major_bodies, minor_bodies = self._define_major_and_minor_bodies()
 
-        pbar = tqdm.tqdm(self.bodies, desc="Processing", colour = "blue")
-        for body in pbar:
-            pbar.set_description(f"\033[92mCurrently processing {body.name}\033[00m")
-            # with solar_system_ephemeris.set("de430"):
-            #     body_pos = get_body(body.name, Time(body.time))
-            # body_heliocentric_mean_ecliptic = body_pos.transform_to(HeliocentricMeanEcliptic)
-            # body.position = body_heliocentric_mean_ecliptic.cartesian.xyz.to(u.au).value
+        pbar = tqdm.tqdm(
+            total=len(self.bodies),
+            desc="Processing",
+            colour="blue",
+            ncols=80,
+            position=0,
+            leave=True,
+        )
+        pbar_batch = tqdm.tqdm(
+            total=self.number_of_query_batches,
+            desc="Querying JPL Horizons",
+            colour="#cd44dd",
+            leave=False,
+            ncols=50,
+            position=1,
+        )
+        for body in self.bodies:
+            pbar.set_description(f"\033[92mProcessing {body.name}\033[00m")
 
             if body.name.casefold() in major_bodies:
-                id = f'{major_bodies[body.name.casefold()]}'
+                id = f"{major_bodies[body.name.casefold()]}"
             elif body.name.casefold() in minor_bodies:
-                id = f'{body.name}'
+                id = f"{body.name}"
             else:
-                print(f"Body {body.name} not found in major or minor body lists. Skipping.")
-                continue
-
-            obj = Horizons(
-                id=f'{id}', 
-                location='@10', 
-                epochs={
-                    "start": f"{body.time[0].iso}", 
-                    "stop": f"{body.time[-1].iso}", 
-                    "step": f"{int(np.round(self.time_step.to(u.minute).value))}m"
-                    }
+                print(
+                    f"\n\033[91mWarning:\033[00m Body name '{body.name}' not found in major or minor body lists. Attempting to query JPL Horizons with the name directly.\n"
                 )
-            vec = obj.vectors()
+                id = f"{body.name}"
 
-            coordinates = SkyCoord(vec['x'].quantity, vec['y'].quantity, vec['z'].quantity,
-                    representation_type='cartesian', frame='heliocentriceclipticiau76',
-                    obstime=body.time).transform_to(HeliocentricMeanEcliptic)
-            
-            body.position = coordinates.cartesian.xyz.to(u.au).value
+            body.position = np.zeros((3, body.time.size))
+            body.time_mjd = np.zeros(body.time.size)
+
+            pbar_batch.reset()
+            for batch in range(self.number_of_query_batches):
+                pbar_batch.set_description(f"\033[93mBatch\033[00m")
+                batch_start = batch * self.batch_size
+                batch_end = min((batch + 1) * self.batch_size, body.time.size)
+
+                # Query JPL Horizons for the current batch of times for the current body
+                obj = Horizons(
+                    id=f"{id}",  # Celestial body ID
+                    location="@10",  # At center of Sun
+                    epochs={
+                        "start": f"{body.time[batch_start].iso}",
+                        "stop": f"{body.time[batch_end-1].iso}",
+                        "step": f"{int(np.round(self.time_step.to(u.min).value))}m",
+                    },
+                )
+
+                vec = obj.vectors()
+
+                batch_time = body.time[batch_start:batch_end]
+                batch_time_jd = Time(vec["datetime_jd"].data, format="jd", scale="tai")
+
+                # Define the input coordinates in the original frame (assumed to be
+                # heliocentric ecliptic) and transform to Heliocentric Mean Ecliptic frame
+                coordinates = SkyCoord(
+                    vec["x"].quantity,
+                    vec["y"].quantity,
+                    vec["z"].quantity,
+                    representation_type="cartesian",
+                    frame="heliocentriceclipticiau76",
+                    obstime=batch_time,
+                ).transform_to(HeliocentricMeanEcliptic)
+
+                # Writing to buffer arrays for the current batch
+                body.position[:, batch_start:batch_end] = coordinates.cartesian.xyz.to(
+                    u.au
+                ).value
+                body.time_mjd[batch_start:batch_end] = batch_time_jd.mjd
+
+                pbar_batch.update(1)
+
+            # Overwriting body.time with the MJD times from JPL Horizons
+            # to ensure consistency, since the original time grid may not
+            # align perfectly with the queried times due to rounding of
+            # the time step.
+            body.time = Time(body.time_mjd, format="mjd", scale="tai")
+
+            pbar.update(1)
+        pbar_batch.close()
+        pbar.close()
 
     def save_ephemeris(self, outpath: str, save_format: str = "hdf5") -> None:
         """Save ephemeris to disk in text or HDF5 format.
@@ -152,7 +259,11 @@ class EphemerisGenerator:
             for body in self.bodies:
                 body_file_data = np.vstack((body.time.mjd, body.position)).T
                 header = f"{len(body.time)}\nMJD\tX[AU]\tY[AU]\tZ[AU] \t Frame: Heliocentric Mean Ecliptic"
-                np.savetxt(os.path.join(outpath, f"{body.name}_ephemeris.txt"), body_file_data, header=header)
+                np.savetxt(
+                    os.path.join(outpath, f"{body.name}_ephemeris.txt"),
+                    body_file_data,
+                    header=header,
+                )
 
         if save_format == "hdf5":
             print(f"Saving ephemeris to {outpath} in HDF5 format...")
@@ -172,41 +283,68 @@ def parse_commandline_args():
         description="Generate ephemeris for solar system bodies and save to disk."
     )
     parser.add_argument(
-        "--outpath", type=str,
-        help="Output directory for ephemeris files (required)", required=True
+        "--outpath",
+        type=str,
+        help="Output directory for ephemeris files (required)",
+        required=True,
     )
     parser.add_argument(
-        "--format", type=str, choices=["txt", "h5"], default="hdf5",
-        help="Output format for ephemeris files (default: hdf5)"
+        "--format",
+        type=str,
+        choices=["txt", "h5"],
+        default="hdf5",
+        help="Output format for ephemeris files (default: hdf5)",
     )
     parser.add_argument(
-        "--time_step", type=float, default=3600,
-        help="Time step in seconds for ephemeris generation (default: 3600 seconds)"
+        "--time_step",
+        type=float,
+        default=3600,
+        help="Time step in seconds for ephemeris generation (default: 3600 seconds)",
     )
     parser.add_argument(
-        "--start_time", type=str, default="1980-01-01 00:00:00",
-        help="Start time for ephemeris generation in ISO format (default: 1980-01-01 00:00:00)"
+        "--start_time",
+        type=str,
+        default="1980-01-01 00:00:00",
+        help="Start time for ephemeris generation in ISO format (default: 1980-01-01 00:00:00)",
     )
     parser.add_argument(
-        "--end_time", type=str, default="2049-12-31 23:59:59",
-        help="End time for ephemeris generation in ISO format (default: 2049-12-31 23:59:59)"
+        "--end_time",
+        type=str,
+        default="2049-12-31 23:59:59",
+        help="End time for ephemeris generation in ISO format (default: 2049-12-31 23:59:59)",
     )
-    parser.add_argument("--bodies", nargs="+", default=["sun", "moon", "mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"], 
-                        help="List of solar system bodies to include (default: sun moon mercury venus earth mars jupiter saturn uranus neptune)")
-    
+    parser.add_argument(
+        "--bodies",
+        nargs="+",
+        default=[
+            "sun",
+            "moon",
+            "mercury",
+            "venus",
+            "earth",
+            "mars",
+            "jupiter",
+            "saturn",
+            "uranus",
+            "neptune",
+        ],
+        help="List of solar system bodies to include (default: sun moon mercury venus earth mars jupiter saturn uranus neptune)",
+    )
+
     return parser.parse_args()
+
 
 def main() -> None:
 
     args = parse_commandline_args()
 
-    start_time = Time(args.start_time, format='iso', scale='utc').mjd * u.day
-    end_time = Time(args.end_time, format='iso', scale='utc').mjd * u.day
+    start_time = Time(args.start_time, format="iso", scale="utc").mjd * u.day
+    end_time = Time(args.end_time, format="iso", scale="utc").mjd * u.day
 
     ephem_gen = EphemerisGenerator(
-        body_names=args.bodies, 
-        time_step = args.time_step * u.s, 
-        start_time=start_time, 
+        body_names=args.bodies,
+        time_step=args.time_step * u.s,
+        start_time=start_time,
         end_time=end_time,
     )
 
@@ -217,9 +355,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-    
-
-        # print(asteroids)
-
-    #      1 Ceres             61000  2.7656157 0.07957632  10.58789  73.29975  80.24963 231.5397330  3.35  0.12 JPL 48

--- a/commander3/todscripts/AKARI/ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/ephemeris_generator.py
@@ -1,3 +1,22 @@
+"""Generate ephemeris for solar system bodies using JPL Horizons.
+
+This module provides tools to query JPL Horizons for precise positions of solar
+system bodies over a specified time range and save the results in various formats.
+It handles large time ranges by batching queries to respect JPL Horizons API limits.
+
+Typical workflow:
+    1. Create an EphemerisGenerator with desired time range and bodies
+    2. Call define_bodies() to initialize body instances
+    3. Call generate_ephemeris() to query JPL Horizons for positions
+    4. Call save_ephemeris() to write results to disk
+
+Example:
+    >>> ephem = EphemerisGenerator(body_names=["sun", "earth", "mars"])
+    >>> ephem.define_bodies()
+    >>> ephem.generate_ephemeris()
+    >>> ephem.save_ephemeris(outpath="./output", save_format="hdf5")
+"""
+
 from dataclasses import dataclass
 import os
 from typing import Optional
@@ -10,9 +29,6 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import (
     HeliocentricMeanEcliptic,
-    get_body,
-    get_body_barycentric,
-    solar_system_ephemeris,
     SkyCoord,
 )
 from astroquery.jplhorizons import Horizons
@@ -23,7 +39,19 @@ warnings.filterwarnings("ignore")
 
 @dataclass
 class CelestialBody:
-    """Data class for celestial body data."""
+    """Data class for storing celestial body ephemeris data.
+
+    Attributes
+    ----------
+    name : str
+        Name of the celestial body (e.g., 'sun', 'earth', 'mars').
+    time : numpy.ndarray
+        Array of astropy.time.Time objects for which ephemeris is computed.
+    position : numpy.ndarray
+        3xN array of Cartesian coordinates (X, Y, Z in AU) in the heliocentric
+        mean ecliptic frame. Shape is (3, len(time)) where axis 0 contains
+        [X, Y, Z] components.
+    """
 
     name: str
     time: np.ndarray
@@ -35,11 +63,11 @@ class EphemerisGenerator:
         self,
         body_names: list[str],
         start_time: Optional[u.quantity.Quantity] = Time(
-            "1980-01-01 00:00:00.000", format="iso", scale="utc"
+            "1980-01-01 00:00:00.000", format="iso", scale="tdb"
         ).mjd
         * u.day,
         end_time: Optional[u.quantity.Quantity] = Time(
-            "2049-12-31 23:59:59.999", format="iso", scale="utc"
+            "2049-12-31 23:59:59.999", format="iso", scale="tdb"
         ).mjd
         * u.day,
         time_step: Optional[u.quantity.Quantity] = 3600 * u.s,
@@ -51,9 +79,9 @@ class EphemerisGenerator:
         body_names : list of str
             List of solar system body names understood by Astropy.
         start_mjd : astropy.units.Quantity, optional
-            Start time in MJD with units (default 1980-01-01 UTC).
+            Start time in MJD with units (default 1980-01-01 TDB).
         end_mjd : astropy.units.Quantity, optional
-            End time in MJD with units (default 2049-12-31 UTC).
+            End time in MJD with units (default 2049-12-31 TDB).
         time_step : astropy.units.Quantity, optional
             Time step as an Astropy quantity (default 3600 s).
         """
@@ -62,7 +90,7 @@ class EphemerisGenerator:
         self.end_time = end_time
         self.time_step = time_step
         self.time_arr = (
-            Time(self.start_time, format="mjd", scale="tai")
+            Time(self.start_time, format="mjd", scale="tdb")
             + np.arange(
                 0,
                 (self.end_time - self.start_time).to(u.min).value,
@@ -72,9 +100,9 @@ class EphemerisGenerator:
         )
 
         self.jpl_horizons_query_limit = 90024
-        self.number_of_query_batches = int(
+        self.number_of_query_batches = max(1, int(
             np.ceil(self.time_arr.size / self.jpl_horizons_query_limit)
-        )
+        ))
         self.batch_size = int(
             np.ceil(self.time_arr.size / self.number_of_query_batches)
         )
@@ -140,23 +168,56 @@ class EphemerisGenerator:
         minor_bodies = {}
         with open(path2asteroid_def, "r") as f:
             asteroid_lines = f.readlines()
+
+            # Parse column widths from header line (line 1)
             column_widths = []
             for column in asteroid_lines[1].split():
                 column_widths.append(len(column))
+
+            # Parse asteroid data rows (starting from line 2)
+            # Extract columns at fixed positions based on header column widths
             for line in asteroid_lines[2:]:
                 previous_width = 0
                 columns = []
+                # Extract each column value at its fixed position
                 for width in column_widths:
                     columns.append(
                         line[previous_width : previous_width + width + 1].strip()
                     )
                     previous_width = previous_width + width + 1
+                # Store asteroid name (column 1) -> ID (column 0) mapping
                 minor_bodies[columns[1].casefold()] = columns[0]
 
         return major_bodies, minor_bodies
 
     def generate_ephemeris(self):
-        """Populate body positions in the heliocentric mean ecliptic frame."""
+        """Query JPL Horizons and populate body positions in heliocentric mean ecliptic frame.
+
+        This method queries JPL Horizons API for precise positions of each body over
+        the time range specified during initialization. To handle large time ranges
+        that exceed JPL Horizons limits (90024 epochs per query), the time range is
+        automatically divided into batches.
+
+        The positions are transformed from the JPL Horizons ecliptic frame
+        (heliocentriceclipticiau76) to the heliocentric mean ecliptic frame for
+        consistency and are stored in AU.
+
+        Raises
+        ------
+        ValueError
+            If JPL Horizons query fails.
+        Warning:
+            If a celestial body cannot be found in major or minor body lists,
+            a warning is printed and the code attempts to query JPL Horizons with the name directly,
+            which may lead to query failures if the name is not recognized by JPL Horizons.
+
+        Notes
+        -----
+        - Bodies are identified by JPL ID numbers (major bodies) or names (minor bodies)
+        - Querying is batched to respect JPL Horizons API limits
+        - All times are in TDB (Barycentric Dynamical Time) scale
+        - Progress bars show both overall processing and batch query status
+        """
         print("Generating ephemeris for celestial bodies...")
 
         major_bodies, minor_bodies = self._define_major_and_minor_bodies()
@@ -213,7 +274,7 @@ class EphemerisGenerator:
                 vec = obj.vectors()
 
                 batch_time = body.time[batch_start:batch_end]
-                batch_time_jd = Time(vec["datetime_jd"].data, format="jd", scale="tai")
+                batch_time_jd = Time(vec["datetime_jd"].data, format="jd", scale="tdb")
 
                 # Define the input coordinates in the original frame (assumed to be
                 # heliocentric ecliptic) and transform to Heliocentric Mean Ecliptic frame
@@ -238,49 +299,87 @@ class EphemerisGenerator:
             # to ensure consistency, since the original time grid may not
             # align perfectly with the queried times due to rounding of
             # the time step.
-            body.time = Time(body.time_mjd, format="mjd", scale="tai")
+            body.time = Time(body.time_mjd, format="mjd", scale="tdb")
 
             pbar.update(1)
         pbar_batch.close()
         pbar.close()
 
-    def save_ephemeris(self, outpath: str, save_format: str = "hdf5") -> None:
-        """Save ephemeris to disk in text or HDF5 format.
+    def save_ephemeris(self, outpath: str, save_format="hdf5") -> None:
+        """Save computed ephemeris to disk in text and/or HDF5 format.
 
         Parameters
         ----------
         outpath : str
-            Output directory path.
-        save_format : str, optional
-            Output format, either "txt" or "hdf5".
-        """
-        if save_format == "txt":
-            print(f"Saving ephemeris to {outpath} in txt format...")
-            for body in self.bodies:
-                body_file_data = np.vstack((body.time.mjd, body.position)).T
-                header = f"{len(body.time)}\nMJD\tX[AU]\tY[AU]\tZ[AU] \t Frame: Heliocentric Mean Ecliptic"
-                np.savetxt(
-                    os.path.join(outpath, f"{body.name}_ephemeris.txt"),
-                    body_file_data,
-                    header=header,
-                )
+            Output directory path where files will be saved.
+        save_format : str or list, optional
+            Output format specification. Can be:
+            - "txt": One file per body as tab-separated text with columns:
+              [MJD, X[AU], Y[AU], Z[AU]] in heliocentric mean ecliptic frame
+            - "hdf5" or "h5": Single HDF5 file with structure:
+              /body_name/time_mjd (dataset)
+              /body_name/position_au (dataset with metadata)
+            - "both": Generate both txt and HDF5 output files
+            - list: List of formats to generate (e.g., ["txt", "hdf5"])
+            Default is "hdf5".
 
-        if save_format == "hdf5":
-            print(f"Saving ephemeris to {outpath} in HDF5 format...")
-            with h5py.File(os.path.join(outpath, "ephemeris.h5"), "w") as f:
+        Notes
+        -----
+        Text format includes a header with the number of epochs and coordinate info.
+        HDF5 format includes attributes specifying units (AU) and coordinate frame.
+        """
+        # Normalize save_format to a list
+        if isinstance(save_format, str):
+            if save_format == "both":
+                formats = ["txt", "hdf5"]
+            else:
+                formats = [save_format]
+        else:
+            formats = save_format
+
+        for fmt in formats:
+            if fmt == "txt":
+                print(f"Saving ephemeris to {outpath} in txt format...")
                 for body in self.bodies:
-                    grp = f.create_group(body.name)
-                    grp.create_dataset("time_mjd", data=body.time.mjd)
-                    grp.create_dataset("position_au", data=body.position)
-                    grp["position_au"].attrs["units"] = "au"
-                    grp["position_au"].attrs["frame"] = "heliocentric_mean_ecliptic"
+                    body_file_data = np.vstack((body.time.mjd, body.position)).T
+                    header = f"{len(body.time)}\nMJD\tX[AU]\tY[AU]\tZ[AU] \t Frame: Heliocentric Mean Ecliptic"
+                    np.savetxt(
+                        os.path.join(outpath, f"{body.name}_ephemeris.txt"),
+                        body_file_data,
+                        header=header,
+                    )
+
+            elif fmt in ["hdf5", "h5"]:
+                print(f"Saving ephemeris to {outpath} in HDF5 format...")
+                with h5py.File(os.path.join(outpath, "ephemeris.h5"), "w") as f:
+                    for body in self.bodies:
+                        grp = f.create_group(body.name)
+                        grp.create_dataset("time_mjd", data=body.time.mjd)
+                        grp.create_dataset("position_au", data=body.position)
+                        grp["position_au"].attrs["units"] = "au"
+                        grp["position_au"].attrs["frame"] = "heliocentric_mean_ecliptic"
+            else:
+                print(f"Warning: Unknown format '{fmt}'. Skipping. Valid formats: txt, hdf5, h5, both")
 
 
 def parse_commandline_args():
-    """Parse command-line arguments for ephemeris generation."""
+    """Parse command-line arguments for ephemeris generation.
+
+    Example
+    -------
+    python ephemeris_generator.py --outpath ./output --format hdf5 --time_step 3600 --start_time "2000-01-01 00:00:00" --end_time "2000-01-02 00:00:00" --bodies sun earth mars ceres pallas
+    python ephemeris_generator.py --outpath ./output --format both --time_step 3600 --start_mjd 51544.0 --end_mjd 51545.0 --bodies sun earth mars
+    """
 
     parser = argparse.ArgumentParser(
-        description="Generate ephemeris for solar system bodies and save to disk."
+        description="""
+        Generate ephemeris for solar system bodies and save to disk.
+
+        Example usage:
+          python ephemeris_generator.py --outpath ./output --format hdf5 --time_step 3600 --start_time "2000-01-01 00:00:00" --end_time "2000-01-02 00:00:00" --bodies sun earth mars ceres pallas
+          python ephemeris_generator.py --outpath ./output --format hdf5 --time_step 3600 --start_mjd 51544.0 --end_mjd 51545.0 --bodies sun earth mars
+        """,
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument(
         "--outpath",
@@ -291,9 +390,9 @@ def parse_commandline_args():
     parser.add_argument(
         "--format",
         type=str,
-        choices=["txt", "h5"],
+        choices=["txt", "hdf5", "h5", "both"],
         default="hdf5",
-        help="Output format for ephemeris files (default: hdf5)",
+        help="Output format for ephemeris files. Options: txt, hdf5, h5, both (default: hdf5)",
     )
     parser.add_argument(
         "--time_step",
@@ -301,18 +400,33 @@ def parse_commandline_args():
         default=3600,
         help="Time step in seconds for ephemeris generation (default: 3600 seconds)",
     )
-    parser.add_argument(
+
+    # Create mutually exclusive group for start time
+    start_group = parser.add_mutually_exclusive_group(required=False)
+    start_group.add_argument(
         "--start_time",
         type=str,
-        default="1980-01-01 00:00:00",
-        help="Start time for ephemeris generation in ISO format (default: 1980-01-01 00:00:00)",
+        help="Start time in ISO format (default: 1980-01-01 00:00:00 TDB)",
     )
-    parser.add_argument(
+    start_group.add_argument(
+        "--start_mjd",
+        type=float,
+        help="Start time as Modified Julian Date (default: 44239, which corresponds to 1980-01-01 00:00:00 TDB)",
+    )
+
+    # Create mutually exclusive group for end time
+    end_group = parser.add_mutually_exclusive_group(required=False)
+    end_group.add_argument(
         "--end_time",
         type=str,
-        default="2049-12-31 23:59:59",
-        help="End time for ephemeris generation in ISO format (default: 2049-12-31 23:59:59)",
+        help="End time in ISO format (default: 2049-12-31 23:59:59 TDB)",
     )
+    end_group.add_argument(
+        "--end_mjd",
+        type=float,
+        help="End time as Modified Julian Date (default: 69806.99998843, which corresponds to 2049-12-31 23:59:59 TDB)",
+    )
+
     parser.add_argument(
         "--bodies",
         nargs="+",
@@ -327,6 +441,9 @@ def parse_commandline_args():
             "saturn",
             "uranus",
             "neptune",
+            "ceres",
+            "pallas",
+            "vesta",
         ],
         help="List of solar system bodies to include (default: sun moon mercury venus earth mars jupiter saturn uranus neptune)",
     )
@@ -335,11 +452,31 @@ def parse_commandline_args():
 
 
 def main() -> None:
+    """Main entry point for ephemeris generation workflow.
+
+    Parses command-line arguments, creates an EphemerisGenerator instance,
+    runs the ephemeris generation pipeline, and saves results to disk.
+    """
 
     args = parse_commandline_args()
 
-    start_time = Time(args.start_time, format="iso", scale="utc").mjd * u.day
-    end_time = Time(args.end_time, format="iso", scale="utc").mjd * u.day
+    # Handle start time - use ISO if provided, otherwise use MJD (or default)
+    if args.start_time:
+        start_time = Time(args.start_time, format="iso", scale="tdb").mjd * u.day
+    elif args.start_mjd:
+        start_time = args.start_mjd * u.day
+    else:
+        # Default: 1980-01-01 00:00:00 TDB
+        start_time = Time("1980-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+
+    # Handle end time - use ISO if provided, otherwise use MJD (or default)
+    if args.end_time:
+        end_time = Time(args.end_time, format="iso", scale="tdb").mjd * u.day
+    elif args.end_mjd:
+        end_time = args.end_mjd * u.day
+    else:
+        # Default: 2049-12-31 23:59:59 TDB
+        end_time = Time("2049-12-31 23:59:59", format="iso", scale="tdb").mjd * u.day
 
     ephem_gen = EphemerisGenerator(
         body_names=args.bodies,

--- a/commander3/todscripts/AKARI/ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/ephemeris_generator.py
@@ -1,0 +1,225 @@
+from dataclasses import dataclass
+import os
+from typing import Optional
+import warnings
+import argparse
+
+import tqdm
+import h5py
+import numpy as np
+import astropy.units as u
+from astropy.coordinates import HeliocentricMeanEcliptic, get_body, get_body_barycentric, solar_system_ephemeris, SkyCoord
+from astroquery.jplhorizons import Horizons
+from astropy.time import Time
+
+warnings.filterwarnings("ignore")
+
+@dataclass
+class CelestialBody:
+    """Data class for celestial body data."""
+    name: str
+    time: np.ndarray
+    position: np.ndarray
+
+class EphemerisGenerator:
+    def __init__(self, 
+                body_names: list[str], 
+                start_time: Optional[u.quantity.Quantity] = Time("1980-01-01 00:00:00.000", format='iso', scale='utc').mjd * u.day, 
+                end_time: Optional[u.quantity.Quantity] = Time("2049-12-31 23:59:59.999", format='iso', scale='utc').mjd * u.day, 
+                time_step: Optional[u.quantity.Quantity] = 3600 * u.s
+        ) -> None:
+        """Initialize ephemeris generation parameters and time grid.
+
+        Parameters
+        ----------
+        body_names : list of str
+            List of solar system body names understood by Astropy.
+        start_mjd : astropy.units.Quantity, optional
+            Start time in MJD with units (default 1980-01-01 UTC).
+        end_mjd : astropy.units.Quantity, optional
+            End time in MJD with units (default 2049-12-31 UTC).
+        time_step : astropy.units.Quantity, optional
+            Time step as an Astropy quantity (default 3600 s).
+        """
+        self.body_names = body_names
+        self.start_time = start_time
+        self.end_time = end_time
+        self.time_step = time_step
+        self.time_arr = (Time(self.start_time, format='mjd', scale='utc') 
+                            + np.arange(0, (self.end_time - self.start_time).to(u.min).value, 
+                                        int(np.round(self.time_step.to(u.min).value))) * u.min)
+        
+        
+        self.jpl_horizons_query_limit = 90024
+
+        # if self.time_arr.size > self.jpl_horizons_query_limit:
+        #     raise ValueError(f"Too many time steps ({self.time_arr.size}) for JPL Horizons, maximum is {self.jpl_horizons_query_limit}. Reduce the number of steps by increasing the time step or reducing the time range.")
+    
+    def define_bodies(self, time_arrs: Optional[list[Time]] = None) -> None:
+        """Create internal `CelestialBody` entries with associated time arrays.
+
+        Parameters
+        ----------
+        time_arrs : list of astropy.time.Time, optional
+            Optional list of time arrays to assign per body. If None, uses the
+            generator-wide `self.time_arr` for all bodies.
+        """
+        
+        self.bodies = []
+
+        print("Defining celestial bodies and associated time arrays...")
+        if time_arrs is not None:
+            for body, time_arr in zip(self.body_names, time_arrs):
+                self.bodies.append(CelestialBody(name=body, time=time_arr, position=None))
+        else:
+            for body in self.body_names:
+                self.bodies.append(CelestialBody(name=body, time=self.time_arr, position=None))
+
+    def _define_major_and_minor_bodies(self):
+        major_bodies = {"sun": 10, "moon": 301, "mercury": 199, "venus": 299, "earth": 399, "mars": 499, "jupiter": 599, "saturn": 699, "uranus": 799, "neptune": 899, "pluto": 999}
+
+        orbital_element_path = "/mn/stornext/d23/cmbco/globe/common/aux/"
+        path2asteroid_def = os.path.join(orbital_element_path, "asteroid_orbital_elements.txt")
+
+        minor_bodies = {}
+        with open(path2asteroid_def, "r") as f:
+            asteroid_lines = f.readlines()
+            column_widths = []
+            for column in asteroid_lines[1].split():
+                column_widths.append(len(column))
+            number_of_columns = len(column_widths)
+            for line in asteroid_lines[2:]:
+                previous_width = 0
+                columns = []
+                for i, width in enumerate(column_widths):
+                    columns.append(line[previous_width:previous_width+width + 1].strip())
+                    previous_width = previous_width + width + 1
+                minor_bodies[columns[1].casefold()] = columns[0]
+        
+        return major_bodies, minor_bodies
+
+    def generate_ephemeris(self):
+        """Populate body positions in the heliocentric mean ecliptic frame."""
+        print("Generating ephemeris for celestial bodies...")
+
+        major_bodies, minor_bodies = self._define_major_and_minor_bodies()
+
+        pbar = tqdm.tqdm(self.bodies, desc="Processing", colour = "blue")
+        for body in pbar:
+            pbar.set_description(f"\033[92mCurrently processing {body.name}\033[00m")
+            # with solar_system_ephemeris.set("de430"):
+            #     body_pos = get_body(body.name, Time(body.time))
+            # body_heliocentric_mean_ecliptic = body_pos.transform_to(HeliocentricMeanEcliptic)
+            # body.position = body_heliocentric_mean_ecliptic.cartesian.xyz.to(u.au).value
+
+            if body.name.casefold() in major_bodies:
+                id = f'{major_bodies[body.name.casefold()]}'
+            elif body.name.casefold() in minor_bodies:
+                id = f'{body.name}'
+            else:
+                print(f"Body {body.name} not found in major or minor body lists. Skipping.")
+                continue
+
+            obj = Horizons(
+                id=f'{id}', 
+                location='@10', 
+                epochs={
+                    "start": f"{body.time[0].iso}", 
+                    "stop": f"{body.time[-1].iso}", 
+                    "step": f"{int(np.round(self.time_step.to(u.minute).value))}m"
+                    }
+                )
+            vec = obj.vectors()
+
+            coordinates = SkyCoord(vec['x'].quantity, vec['y'].quantity, vec['z'].quantity,
+                    representation_type='cartesian', frame='heliocentriceclipticiau76',
+                    obstime=body.time).transform_to(HeliocentricMeanEcliptic)
+            
+            body.position = coordinates.cartesian.xyz.to(u.au).value
+
+    def save_ephemeris(self, outpath: str, save_format: str = "hdf5") -> None:
+        """Save ephemeris to disk in text or HDF5 format.
+
+        Parameters
+        ----------
+        outpath : str
+            Output directory path.
+        save_format : str, optional
+            Output format, either "txt" or "hdf5".
+        """
+        if save_format == "txt":
+            print(f"Saving ephemeris to {outpath} in txt format...")
+            for body in self.bodies:
+                body_file_data = np.vstack((body.time.mjd, body.position)).T
+                header = f"{len(body.time)}\nMJD\tX[AU]\tY[AU]\tZ[AU] \t Frame: Heliocentric Mean Ecliptic"
+                np.savetxt(os.path.join(outpath, f"{body.name}_ephemeris.txt"), body_file_data, header=header)
+
+        if save_format == "hdf5":
+            print(f"Saving ephemeris to {outpath} in HDF5 format...")
+            with h5py.File(os.path.join(outpath, "ephemeris.h5"), "w") as f:
+                for body in self.bodies:
+                    grp = f.create_group(body.name)
+                    grp.create_dataset("time_mjd", data=body.time.mjd)
+                    grp.create_dataset("position_au", data=body.position)
+                    grp["position_au"].attrs["units"] = "au"
+                    grp["position_au"].attrs["frame"] = "heliocentric_mean_ecliptic"
+
+
+def parse_commandline_args():
+    """Parse command-line arguments for ephemeris generation."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate ephemeris for solar system bodies and save to disk."
+    )
+    parser.add_argument(
+        "--outpath", type=str,
+        help="Output directory for ephemeris files (required)", required=True
+    )
+    parser.add_argument(
+        "--format", type=str, choices=["txt", "h5"], default="hdf5",
+        help="Output format for ephemeris files (default: hdf5)"
+    )
+    parser.add_argument(
+        "--time_step", type=float, default=3600,
+        help="Time step in seconds for ephemeris generation (default: 3600 seconds)"
+    )
+    parser.add_argument(
+        "--start_time", type=str, default="1980-01-01 00:00:00",
+        help="Start time for ephemeris generation in ISO format (default: 1980-01-01 00:00:00)"
+    )
+    parser.add_argument(
+        "--end_time", type=str, default="2049-12-31 23:59:59",
+        help="End time for ephemeris generation in ISO format (default: 2049-12-31 23:59:59)"
+    )
+    parser.add_argument("--bodies", nargs="+", default=["sun", "moon", "mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune"], 
+                        help="List of solar system bodies to include (default: sun moon mercury venus earth mars jupiter saturn uranus neptune)")
+    
+    return parser.parse_args()
+
+def main() -> None:
+
+    args = parse_commandline_args()
+
+    start_time = Time(args.start_time, format='iso', scale='utc').mjd * u.day
+    end_time = Time(args.end_time, format='iso', scale='utc').mjd * u.day
+
+    ephem_gen = EphemerisGenerator(
+        body_names=args.bodies, 
+        time_step = args.time_step * u.s, 
+        start_time=start_time, 
+        end_time=end_time,
+    )
+
+    ephem_gen.define_bodies()
+    ephem_gen.generate_ephemeris()
+    ephem_gen.save_ephemeris(outpath=args.outpath, save_format=args.format)
+
+
+if __name__ == "__main__":
+    main()
+
+    
+
+        # print(asteroids)
+
+    #      1 Ceres             61000  2.7656157 0.07957632  10.58789  73.29975  80.24963 231.5397330  3.35  0.12 JPL 48

--- a/commander3/todscripts/AKARI/unit_tests/test_ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/unit_tests/test_ephemeris_generator.py
@@ -1,0 +1,838 @@
+"""Test suite for ephemeris_generator.py module.
+
+This test suite includes both fast mocked tests and slow integration tests that
+perform actual JPL Horizons queries.
+
+Usage Examples
+--------------
+
+Run all tests (fast mocked tests only):
+    pytest test_ephemeris_generator.py -v
+
+Run all tests including slow integration tests:
+    pytest test_ephemeris_generator.py -v -m slow
+
+Run only real JPL Horizons query tests:
+    pytest test_ephemeris_generator.py -m real_query -v
+
+Run specific test class:
+    pytest test_ephemeris_generator.py::TestArgumentParsing -v
+
+Run specific test:
+    pytest test_ephemeris_generator.py::TestIntegration::test_sun_position_at_origin -v
+
+Run tests and show detailed output:
+    pytest test_ephemeris_generator.py -vv -s
+
+Skip slow tests explicitly:
+    pytest test_ephemeris_generator.py -v -m "not slow"
+
+Run with coverage report:
+    pytest test_ephemeris_generator.py --cov=ephemeris_generator --cov-report=html
+
+Available markers:
+    - slow: Tests that take longer to run (integration tests)
+    - real_query: Tests that make actual JPL Horizons API calls
+"""
+
+import sys
+import os
+import pytest
+import argparse
+import tempfile
+import numpy as np
+import h5py
+from unittest.mock import Mock, patch, MagicMock
+import astropy.units as u
+from astropy.time import Time
+
+# Add parent directory to path so we can import ephemeris_generator
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ephemeris_generator import (
+    EphemerisGenerator,
+    CelestialBody,
+    parse_commandline_args,
+    main,
+)
+
+
+# ============================================================================
+# Argument Parsing Tests
+# ============================================================================
+
+
+class TestArgumentParsing:
+    """Test command-line argument parsing."""
+
+    def test_mutually_exclusive_start_time_args(self):
+        """Test that ISO and MJD start time formats cannot be used simultaneously."""
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                [
+                    "ephemeris_generator.py",
+                    "--outpath",
+                    "/tmp/test",
+                    "--start_time",
+                    "2000-01-01 00:00:00",
+                    "--start_mjd",
+                    "51544.0",
+                ],
+            ):
+                parse_commandline_args()
+
+    def test_mutually_exclusive_end_time_args(self):
+        """Test that ISO and MJD end time formats cannot be used simultaneously."""
+        with pytest.raises(SystemExit):
+            with patch(
+                "sys.argv",
+                [
+                    "ephemeris_generator.py",
+                    "--outpath",
+                    "/tmp/test",
+                    "--end_time",
+                    "2000-01-01 00:00:00",
+                    "--end_mjd",
+                    "51544.0",
+                ],
+            ):
+                parse_commandline_args()
+
+    def test_required_outpath_argument(self):
+        """Test that outpath argument is required."""
+        with pytest.raises(SystemExit):
+            with patch("sys.argv", ["ephemeris_generator.py"]):
+                parse_commandline_args()
+
+    def test_valid_argument_parsing(self):
+        """Test valid argument combinations are accepted."""
+        with patch(
+            "sys.argv",
+            [
+                "ephemeris_generator.py",
+                "--outpath",
+                "/tmp/test",
+                "--start_time",
+                "2000-01-01 00:00:00",
+                "--end_time",
+                "2000-01-02 00:00:00",
+                "--bodies",
+                "sun",
+                "earth",
+            ],
+        ):
+            args = parse_commandline_args()
+            assert args.outpath == "/tmp/test"
+            assert args.start_time == "2000-01-01 00:00:00"
+            assert args.end_time == "2000-01-02 00:00:00"
+            assert args.bodies == ["sun", "earth"]
+
+    def test_mjd_time_arguments(self):
+        """Test MJD time arguments are parsed correctly."""
+        with patch(
+            "sys.argv",
+            [
+                "ephemeris_generator.py",
+                "--outpath",
+                "/tmp/test",
+                "--start_mjd",
+                "51544.0",
+                "--end_mjd",
+                "51545.0",
+            ],
+        ):
+            args = parse_commandline_args()
+            assert args.start_mjd == 51544.0
+            assert args.end_mjd == 51545.0
+
+
+# ============================================================================
+# Time Handling Tests
+# ============================================================================
+
+
+class TestTimeHandling:
+    """Test time array generation and batch calculations."""
+
+    def test_time_array_generation_hourly(self):
+        """Test time array generation with 1-hour steps."""
+        start = Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+        end = Time("2000-01-02 00:00:00", format="iso", scale="tdb").mjd * u.day
+        time_step = 3600 * u.s
+
+        gen = EphemerisGenerator(
+            body_names=["sun"], start_time=start, end_time=end, time_step=time_step
+        )
+
+        # Should have 24 time steps (0-23 hours inclusive = 25 points, but depends on implementation)
+        # Let's check the array exists and has reasonable length
+        assert len(gen.time_arr) > 0
+        assert len(gen.time_arr) <= 25  # At most 25 for 24 hours + endpoint
+
+    def test_time_array_generation_daily(self):
+        """Test time array generation with 1-day steps."""
+        start = Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+        end = Time("2000-01-10 00:00:00", format="iso", scale="tdb").mjd * u.day
+        time_step = 86400 * u.s
+
+        gen = EphemerisGenerator(
+            body_names=["sun"], start_time=start, end_time=end, time_step=time_step
+        )
+
+        assert len(gen.time_arr) >= 9
+        assert len(gen.time_arr) <= 11
+
+    def test_batch_calculation_small_array(self):
+        """Test batch calculation for arrays smaller than JPL limit."""
+        start = Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+        end = Time("2000-01-02 00:00:00", format="iso", scale="tdb").mjd * u.day
+        time_step = 3600 * u.s
+
+        gen = EphemerisGenerator(
+            body_names=["sun"], start_time=start, end_time=end, time_step=time_step
+        )
+
+        # Should only need 1 batch for small time range
+        assert gen.number_of_query_batches == 1
+        assert gen.batch_size >= len(gen.time_arr)
+
+    def test_batch_calculation_large_array(self):
+        """Test batch calculation for arrays requiring multiple batches."""
+        # Create generator with more than 90024 time steps
+        start = Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+        end = Time("2050-01-01 00:00:00", format="iso", scale="tdb").mjd * u.day
+        time_step = 3600 * u.s
+
+        gen = EphemerisGenerator(
+            body_names=["sun"], start_time=start, end_time=end, time_step=time_step
+        )
+
+        # Should require multiple batches
+        assert gen.number_of_query_batches > 1
+        # Verify batches cover all time steps
+        total_coverage = gen.batch_size * gen.number_of_query_batches
+        assert total_coverage >= len(gen.time_arr)
+
+
+# ============================================================================
+# Body Definition Tests
+# ============================================================================
+
+
+class TestBodyDefinition:
+    """Test celestial body recognition and definition."""
+
+    def test_major_body_identification(self):
+        """Test major solar system bodies are correctly identified."""
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth", "mars", "jupiter"],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+        )
+
+        major_bodies, _ = gen._define_major_and_minor_bodies()
+
+        assert "sun" in major_bodies
+        assert major_bodies["sun"] == 10
+        assert "earth" in major_bodies
+        assert major_bodies["earth"] == 399
+        assert "mars" in major_bodies
+        assert major_bodies["mars"] == 499
+        assert "jupiter" in major_bodies
+        assert major_bodies["jupiter"] == 599
+
+    def test_casefold_body_matching(self):
+        """Test that body name matching is case-insensitive."""
+        gen = EphemerisGenerator(
+            body_names=["SUN", "Earth", "MARS"],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+        )
+
+        major_bodies, _ = gen._define_major_and_minor_bodies()
+
+        # All should match despite different cases
+        assert "sun" in major_bodies
+        assert "earth" in major_bodies
+        assert "mars" in major_bodies
+
+    def test_define_bodies_creates_list(self):
+        """Test define_bodies creates body list."""
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth"],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+        )
+        gen.define_bodies()
+
+        assert len(gen.bodies) == 2
+        assert all(isinstance(body, CelestialBody) for body in gen.bodies)
+        assert gen.bodies[0].name == "sun"
+        assert gen.bodies[1].name == "earth"
+
+    def test_custom_time_arrays(self):
+        """Test bodies can be defined with custom time arrays."""
+        custom_times = [
+            Time("2000-01-01 00:00:00", format="iso", scale="tdb")
+            + np.arange(0, 10) * u.hour,
+            Time("2000-01-01 00:00:00", format="iso", scale="tdb")
+            + np.arange(0, 5) * u.hour,
+        ]
+
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth"],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+        )
+        gen.define_bodies(time_arrs=custom_times)
+
+        assert len(gen.bodies[0].time) == 10
+        assert len(gen.bodies[1].time) == 5
+
+
+# ============================================================================
+# CelestialBody Dataclass Tests
+# ============================================================================
+
+
+class TestCelestialBodyDataclass:
+    """Test CelestialBody dataclass."""
+
+    def test_celestial_body_creation(self):
+        """Test CelestialBody can be created with correct attributes."""
+        time_arr = (
+            Time("2000-01-01 00:00:00", format="iso", scale="tdb")
+            + np.arange(0, 10) * u.hour
+        )
+        position = np.random.rand(3, 10)
+
+        body = CelestialBody(name="earth", time=time_arr, position=position)
+
+        assert body.name == "earth"
+        assert len(body.time) == 10
+        assert body.position.shape == (3, 10)
+
+    def test_celestial_body_none_position(self):
+        """Test CelestialBody can be created with None position."""
+        time_arr = (
+            Time("2000-01-01 00:00:00", format="iso", scale="tdb")
+            + np.arange(0, 10) * u.hour
+        )
+
+        body = CelestialBody(name="mars", time=time_arr, position=None)
+
+        assert body.name == "mars"
+        assert body.position is None
+
+
+# ============================================================================
+# File I/O Tests
+# ============================================================================
+
+
+class TestFileIO:
+    """Test ephemeris file output."""
+
+    def test_hdf5_output_structure(self):
+        """Test HDF5 file has correct structure."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = EphemerisGenerator(
+                body_names=["sun"],
+                start_time=51544.0 * u.day,
+                end_time=51544.1 * u.day,
+                time_step=3600 * u.s,
+            )
+            gen.define_bodies()
+
+            # Create mock position data
+            gen.bodies[0].position = np.random.rand(3, 3)
+            gen.bodies[0].time_mjd = np.array([51544.0, 51544.04, 51544.08])
+
+            gen.save_ephemeris(outpath=tmpdir, save_format="hdf5")
+
+            # Verify file exists and has correct structure
+            hdf5_path = os.path.join(tmpdir, "ephemeris.h5")
+            assert os.path.exists(hdf5_path)
+
+            with h5py.File(hdf5_path, "r") as f:
+                assert "sun" in f
+                assert "time_mjd" in f["sun"]
+                assert "position_au" in f["sun"]
+                assert f["sun"]["position_au"].attrs["units"] == "au"
+                assert (
+                    f["sun"]["position_au"].attrs["frame"]
+                    == "heliocentric_mean_ecliptic"
+                )
+
+    def test_text_output_format(self):
+        """Test text file format matches specification."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = EphemerisGenerator(
+                body_names=["earth"],
+                start_time=51544.0 * u.day,
+                end_time=51544.1 * u.day,
+                time_step=3600 * u.s,
+            )
+            gen.define_bodies()
+
+            # Create mock position data
+            gen.bodies[0].position = np.random.rand(3, 3)
+            gen.bodies[0].time = Time([51544.0, 51544.04, 51544.08], format="mjd")
+
+            gen.save_ephemeris(outpath=tmpdir, save_format="txt")
+
+            # Verify file exists
+            txt_path = os.path.join(tmpdir, "earth_ephemeris.txt")
+            assert os.path.exists(txt_path)
+
+            # Read and verify format
+            with open(txt_path, "r") as f:
+                lines = f.readlines()
+                # Should have header lines and data lines
+                assert len(lines) > 3
+                # Check header contains expected info
+                assert "MJD" in lines[1]
+                assert "AU" in lines[1]
+
+    def test_multiple_bodies_hdf5(self):
+        """Test HDF5 output with multiple bodies."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = EphemerisGenerator(
+                body_names=["sun", "earth", "mars"],
+                start_time=51544.0 * u.day,
+                end_time=51544.1 * u.day,
+                time_step=3600 * u.s,
+            )
+            gen.define_bodies()
+
+            # Create mock data for all bodies
+            for body in gen.bodies:
+                body.position = np.random.rand(3, 3)
+                body.time_mjd = np.array([51544.0, 51544.04, 51544.08])
+
+            gen.save_ephemeris(outpath=tmpdir, save_format="hdf5")
+
+            hdf5_path = os.path.join(tmpdir, "ephemeris.h5")
+            with h5py.File(hdf5_path, "r") as f:
+                assert "sun" in f
+                assert "earth" in f
+                assert "mars" in f
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_coordinates_have_physical_meaning(self):
+        """Test that real ephemeris coordinates have physically meaningful distances.
+
+        This test queries real JPL Horizons data for inner planets and validates
+        that the heliocentric distances match their known orbital parameters.
+        """
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth", "mars"],
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-06-30 00:00:00", format="iso", scale="tdb").mjd * u.day,
+            time_step=2592000 * u.s,  # ~30 days
+        )
+        gen.define_bodies()
+        gen.generate_ephemeris()
+
+        # Verify Sun is at origin
+        sun_pos = gen.bodies[0].position
+        sun_distances = np.sqrt(np.sum(sun_pos**2, axis=0))
+        assert np.all(
+            sun_distances < 1e-6
+        ), "Sun should be at origin in heliocentric coordinates"
+
+        # Verify Earth is at ~1 AU
+        earth_pos = gen.bodies[1].position
+        earth_distances = np.sqrt(np.sum(earth_pos**2, axis=0))
+        assert np.all(
+            (earth_distances > 0.98) & (earth_distances < 1.02)
+        ), "Earth distances should be approximately 1 AU"
+
+        # Verify Mars is at ~1.5 AU
+        mars_pos = gen.bodies[2].position
+        mars_distances = np.sqrt(np.sum(mars_pos**2, axis=0))
+        assert np.all(
+            (mars_distances > 1.38) & (mars_distances < 1.70)
+        ), "Mars distances should be approximately 1.5 AU"
+
+
+# ============================================================================
+# Edge Case Tests
+# ============================================================================
+
+
+class TestEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_single_time_step(self):
+        """Test with only one time point."""
+        gen = EphemerisGenerator(
+            body_names=["sun"],
+            start_time=51544.0 * u.day,
+            end_time=51544.1 * u.day,  # 2.4 hours
+            time_step=3600 * u.s,  # 1 hour
+        )
+
+        # Should have at least 1 time step (for the start time)
+        assert len(gen.time_arr) >= 1
+        # Should have at most 3 time steps (0h, 1h, 2h)
+        assert len(gen.time_arr) <= 3
+
+    def test_very_large_time_step(self):
+        """Test with time step larger than time range."""
+        gen = EphemerisGenerator(
+            body_names=["sun"],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+            time_step=172800 * u.s,  # 2 days
+        )
+
+        # Should have minimal time steps
+        assert len(gen.time_arr) >= 1
+
+    def test_empty_body_list(self):
+        """Test behavior with no bodies specified."""
+        gen = EphemerisGenerator(
+            body_names=[],
+            start_time=51544.0 * u.day,
+            end_time=51545.0 * u.day,
+        )
+        gen.define_bodies()
+
+        assert len(gen.bodies) == 0
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestIntegration:
+    """Integration tests for complete workflows."""
+
+    @pytest.mark.slow
+    @patch("ephemeris_generator.Horizons")
+    def test_full_workflow_mocked(self, mock_horizons):
+        """Test complete workflow with mocked JPL Horizons."""
+        # Mock JPL Horizons response
+        mock_vec = MagicMock()
+        mock_vec.__getitem__.side_effect = lambda key: {
+            "x": MagicMock(quantity=np.array([1.0, 1.1, 1.2]) * u.au),
+            "y": MagicMock(quantity=np.array([0.0, 0.1, 0.2]) * u.au),
+            "z": MagicMock(quantity=np.array([0.0, 0.0, 0.1]) * u.au),
+            "datetime_jd": MagicMock(
+                data=np.array([2451544.5, 2451544.54, 2451544.58])
+            ),
+        }[key]
+
+        mock_horizons_instance = MagicMock()
+        mock_horizons_instance.vectors.return_value = mock_vec
+        mock_horizons.return_value = mock_horizons_instance
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            gen = EphemerisGenerator(
+                body_names=["sun"],
+                start_time=51544.0 * u.day,
+                end_time=51544.1 * u.day,
+                time_step=3600 * u.s,
+            )
+            gen.define_bodies()
+            gen.generate_ephemeris()
+            gen.save_ephemeris(outpath=tmpdir, save_format="hdf5")
+
+            # Verify output exists
+            assert os.path.exists(os.path.join(tmpdir, "ephemeris.h5"))
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_sun_position_at_origin(self):
+        """Test that Sun's position is at (0, 0, 0) in heliocentric mean ecliptic coordinates.
+
+        This test performs an actual JPL Horizons query (not mocked).
+        Mark with @pytest.mark.real_query to run only when needed.
+        """
+        # Query a short time range to keep test fast
+        gen = EphemerisGenerator(
+            body_names=["sun"],
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-01-01 12:00:00", format="iso", scale="tdb").mjd * u.day,
+            time_step=3600 * u.s,  # 1 hour
+        )
+        gen.define_bodies()
+        gen.generate_ephemeris()
+
+        # Sun should be at origin in heliocentric coordinates
+        sun_position = gen.bodies[0].position
+
+        # Check all positions are at or very close to (0, 0, 0)
+        # Allow small tolerance for numerical precision
+        tolerance = 1e-10  # AU
+        assert np.all(
+            np.abs(sun_position[0, :]) < tolerance
+        ), "Sun X coordinate not at origin"
+        assert np.all(
+            np.abs(sun_position[1, :]) < tolerance
+        ), "Sun Y coordinate not at origin"
+        assert np.all(
+            np.abs(sun_position[2, :]) < tolerance
+        ), "Sun Z coordinate not at origin"
+
+        # Check the maximum distance from origin
+        distances = np.sqrt(np.sum(sun_position**2, axis=0))
+        max_distance = np.max(distances)
+        assert (
+            max_distance < tolerance
+        ), f"Sun maximum distance from origin {max_distance} AU exceeds tolerance"
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_sun_earth_distance_approximately_1au(self):
+        """Test that distance between Sun and Earth is approximately 1 AU.
+
+        This test performs actual JPL Horizons queries (not mocked).
+        Mark with @pytest.mark.real_query to run only when needed.
+        """
+        # Query a time range covering different parts of Earth's orbit
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth"],
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-07-01 00:00:00", format="iso", scale="tdb").mjd * u.day,
+            time_step=86400
+            * 30
+            * u.s,  # ~30 days to sample different orbital positions
+        )
+        gen.define_bodies()
+        gen.generate_ephemeris()
+
+        # Get positions
+        sun_position = gen.bodies[0].position
+        earth_position = gen.bodies[1].position
+
+        # Calculate distances between Sun and Earth at all time points
+        distances = np.sqrt(np.sum((earth_position - sun_position) ** 2, axis=0))
+
+        # Earth's orbit is elliptical with perihelion ~0.983 AU and aphelion ~1.017 AU
+        # Mean distance should be close to 1 AU
+        mean_distance = np.mean(distances)
+        min_distance = np.min(distances)
+        max_distance = np.max(distances)
+
+        # Check mean distance is close to 1 AU (within 5%)
+        assert (
+            0.95 < mean_distance < 1.05
+        ), f"Mean Sun-Earth distance {mean_distance} AU not close to 1 AU"
+
+        # Check min/max are within expected range for Earth's elliptical orbit
+        assert (
+            0.95 < min_distance < 1.0
+        ), f"Minimum Sun-Earth distance {min_distance} AU outside expected range"
+        assert (
+            1.0 < max_distance < 1.05
+        ), f"Maximum Sun-Earth distance {max_distance} AU outside expected range"
+
+        # Verify all distances are physically reasonable (between 0.9 and 1.1 AU)
+        assert np.all(distances > 0.9), "Some distances unreasonably small"
+        assert np.all(distances < 1.1), "Some distances unreasonably large"
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_queried_time_matches_requested_time(self):
+        """Test that JPL Horizons returns times matching the requested time grid.
+
+        This test verifies that the time array generated by the EphemerisGenerator
+        matches the actual times returned by JPL Horizons queries. This is important
+        because time step rounding or conversion between different time formats
+        could introduce discrepancies.
+
+        This test performs actual JPL Horizons queries (not mocked).
+        """
+        # Use a short time range with specific time step
+        gen = EphemerisGenerator(
+            body_names=["earth"],
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-01-02 00:00:00", format="iso", scale="tdb").mjd * u.day,
+            time_step=3600 * u.s,  # 1 hour
+        )
+        gen.define_bodies()
+
+        # Store the original requested time array
+        requested_time_mjd = gen.bodies[0].time.mjd
+
+        # Query JPL Horizons
+        gen.generate_ephemeris()
+
+        # Get the actual time array returned from JPL Horizons
+        actual_time_mjd = gen.bodies[0].time_mjd
+
+        # Both arrays should have the same length
+        assert len(requested_time_mjd) == len(
+            actual_time_mjd
+        ), f"Time array length mismatch: requested {len(requested_time_mjd)}, got {len(actual_time_mjd)}"
+
+        # Calculate time differences in seconds
+        time_diff_seconds = (
+            actual_time_mjd - requested_time_mjd
+        ) * 86400  # Convert days to seconds
+
+        # Maximum difference should be very small (tolerance: 1 second)
+        # JPL Horizons may have slight rounding in time representation
+        max_diff = np.max(np.abs(time_diff_seconds))
+        assert (
+            max_diff < 1.0
+        ), f"Maximum time difference {max_diff:.3f} seconds exceeds 1 second tolerance"
+
+        # Mean difference should be even smaller
+        mean_diff = np.mean(np.abs(time_diff_seconds))
+        assert (
+            mean_diff < 0.5
+        ), f"Mean time difference {mean_diff:.3f} seconds exceeds 0.5 second tolerance"
+
+        # Verify time spacing is consistent (should match requested time step)
+        requested_spacing = np.diff(requested_time_mjd)
+        actual_spacing = np.diff(actual_time_mjd)
+
+        # Check that spacing is consistent within tolerance
+        spacing_diff = (
+            np.abs(actual_spacing - requested_spacing) * 86400
+        )  # Convert to seconds
+        max_spacing_diff = np.max(spacing_diff)
+        assert (
+            max_spacing_diff < 1.0
+        ), f"Time step consistency error: max difference {max_spacing_diff:.3f} seconds"
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_heliocentric_coordinates_physical_validity(self):
+        """Test that heliocentric coordinates have physically reasonable distances.
+
+        This test validates that:
+        - Inner planets (Mercury, Venus, Earth, Mars) are at ~0.4-1.5 AU
+        - Outer planets (Jupiter, Saturn, Uranus, Neptune) are at their known distances
+        - All bodies maintain approximately their known orbital semi-major axes
+
+        This test performs actual JPL Horizons queries (not mocked).
+        """
+        # Expected approximate semi-major axes in AU
+        expected_distances = {
+            "mercury": (0.35, 0.45),  # perihelion ~0.307, aphelion ~0.467
+            "venus": (0.70, 0.73),  # perihelion ~0.718, aphelion ~0.728
+            "earth": (0.98, 1.02),  # perihelion ~0.983, aphelion ~1.017
+            "mars": (1.38, 1.67),  # perihelion ~1.381, aphelion ~1.666
+            "jupiter": (4.95, 5.45),  # perihelion ~4.950, aphelion ~5.458
+            "saturn": (9.00, 10.05),  # perihelion ~9.020, aphelion ~10.055
+        }
+
+        # Query a time range covering different parts of orbits
+        bodies_to_test = list(expected_distances.keys())
+        gen = EphemerisGenerator(
+            body_names=bodies_to_test,
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-12-31 00:00:00", format="iso", scale="tdb").mjd * u.day,
+            time_step=2592000 * u.s,  # ~30 days
+        )
+        gen.define_bodies()
+        gen.generate_ephemeris()
+
+        # Validate each body's distance from the Sun
+        for i, body_name in enumerate(bodies_to_test):
+            position = gen.bodies[i].position
+
+            # Calculate distances from origin (Sun in heliocentric coordinates)
+            distances = np.sqrt(np.sum(position**2, axis=0))
+
+            min_dist = np.min(distances)
+            max_dist = np.max(distances)
+            mean_dist = np.mean(distances)
+
+            expected_min, expected_max = expected_distances[body_name]
+
+            # Check that measured distances fall within expected ranges
+            assert min_dist >= expected_min * 0.95, (
+                f"{body_name.capitalize()}: minimum distance {min_dist:.3f} AU "
+                f"below expected range [{expected_min:.3f}, {expected_max:.3f}] AU"
+            )
+            assert max_dist <= expected_max * 1.05, (
+                f"{body_name.capitalize()}: maximum distance {max_dist:.3f} AU "
+                f"above expected range [{expected_min:.3f}, {expected_max:.3f}] AU"
+            )
+
+            # Verify mean distance is reasonable
+            assert expected_min * 0.95 <= mean_dist <= expected_max * 1.05, (
+                f"{body_name.capitalize()}: mean distance {mean_dist:.3f} AU "
+                f"outside expected range [{expected_min:.3f}, {expected_max:.3f}] AU"
+            )
+
+    @pytest.mark.slow
+    @pytest.mark.real_query
+    def test_earth_approximately_1au_from_sun(self):
+        """Test that Earth's distance from Sun is approximately 1 AU throughout its orbit.
+
+        This test specifically validates that the Earth's orbital parameters are
+        correctly represented in heliocentric mean ecliptic coordinates by checking
+        that its distance from the Sun (at the origin) is consistently close to 1 AU.
+
+        This test performs actual JPL Horizons queries (not mocked).
+        """
+        # Query Earth over a full year to sample entire orbit
+        gen = EphemerisGenerator(
+            body_names=["sun", "earth"],
+            start_time=Time("2000-01-01 00:00:00", format="iso", scale="tdb").mjd
+            * u.day,
+            end_time=Time("2000-12-31 23:59:59", format="iso", scale="tdb").mjd * u.day,
+            time_step=86400 * u.s,  # 1 day
+        )
+        gen.define_bodies()
+        gen.generate_ephemeris()
+
+        # Get Sun at origin and Earth position
+        sun_pos = gen.bodies[0].position
+        earth_pos = gen.bodies[1].position
+
+        # Calculate heliocentric distance of Earth
+        # In heliocentric coordinates, Sun should be at origin anyway
+        earth_distances = np.sqrt(np.sum(earth_pos**2, axis=0))
+
+        # Statistical validation
+        mean_distance = np.mean(earth_distances)
+        min_distance = np.min(earth_distances)
+        max_distance = np.max(earth_distances)
+        std_distance = np.std(earth_distances)
+
+        # Earth's orbit: perihelion ~0.9833 AU, aphelion ~1.0167 AU
+        # Mean should be very close to 1 AU
+        assert (
+            0.98 < mean_distance < 1.02
+        ), f"Earth mean distance {mean_distance:.6f} AU not close to 1 AU"
+
+        # Check perihelion and aphelion are within expected ranges
+        assert (
+            0.98 < min_distance < 0.99
+        ), f"Earth perihelion {min_distance:.6f} AU outside expected range [0.98, 0.99]"
+        assert (
+            1.01 < max_distance < 1.02
+        ), f"Earth aphelion {max_distance:.6f} AU outside expected range [1.01, 1.02]"
+
+        # Standard deviation should be small (orbit is nearly circular)
+        # Earth's orbital variation is (aphelion - perihelion) / 2 ≈ 0.0167 AU
+        # so std should be roughly 0.0167 / sqrt(12) ≈ 0.0048 AU for uniform distribution
+        assert (
+            std_distance < 0.015
+        ), f"Earth orbital variation {std_distance:.6f} AU is too large"
+
+        # Verify Sun position is at origin (heliocentric)
+        sun_distances = np.sqrt(np.sum(sun_pos**2, axis=0))
+        max_sun_distance = np.max(sun_distances)
+        assert (
+            max_sun_distance < 1e-6
+        ), f"Sun position {max_sun_distance} AU not at origin"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
The ephemeris generator generates vector coordinates for all major and known minor bodies of the solar system (as well as some spacecraft etc. although that is not well tested yet) and outputs them in txt or HDF5 files. All provided coordinates are in heliocentric mean ecliptic coordinates. The user can query the selected objects via the Astropy API of the JPL Horizons system, and the time resolution and range can be configured to match the desired time range. Both MJD and ISO input start and end times are supported, both in Barycentric Dynamical Time (the JPL standard). 

In addition to manually running some sanity checks before submitting the code, some (GitHub Co-pilot modified) test functions have been suggested to test the functionality of the code.