### PR TITLE
AKARI ephemeris flagging

### DIFF
--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -102,8 +102,20 @@ class EphemerisFlagger:
         ]  # Normalize names to lowercase for consistent file naming
 
         proximity_flags = []
+
+        pbar = tqdm.tqdm(
+            total=len(celestial_body_names),
+            desc="Processing",
+            colour="red",
+            ncols=80,
+            position=0,
+            leave=True,
+        )
+
         # Looping through each celestial body to generate flags based on proximity to the observatory's pointing
         for body in celestial_body_names:
+            pbar.set_description(f"\033[92mProcessing {body}\033[00m")
+
             if body not in [
                 os.path.basename(f).replace("_ephemeris.txt", "")
                 for f in self.available_ephemeris_files
@@ -173,7 +185,8 @@ class EphemerisFlagger:
             )
 
             proximity_flags.append(proximity_flag)
-
+            pbar.update(1)
+        pbar.close()
         return proximity_flags
 
 

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -225,19 +225,11 @@ class EphemerisFlagger:
             apparent_lon = relative_spherical_position.lon
             apparent_lat = relative_spherical_position.lat
 
-            # Astropy SkyCoord's "longitude" and "latitude" component names depend on the frame,
-            # so we need to determine the correct component names for the observatory pointing
-            inverse_representation_component_names = {
-                v: k
-                for k, v in observatory_pointing.representation_component_names.items()
-            }
-
-            pointing_lon = getattr(
-                observatory_pointing, inverse_representation_component_names["lon"]
-            )
-            pointing_lat = getattr(
-                observatory_pointing, inverse_representation_component_names["lat"]
-            )
+            # Convert observatory pointing to spherical representation to get lon/lat
+            # (needed because the input might be in cartesian representation)
+            pointing_spherical = observatory_pointing.spherical
+            pointing_lon = pointing_spherical.lon
+            pointing_lat = pointing_spherical.lat
 
             separation = angular_separation(
                 apparent_lon,
@@ -297,70 +289,30 @@ def main():
 
 
 def main2():
-
     import h5py
     from pixell import enmap, utils
     import matplotlib.pyplot as plt
+    from astropy.coordinates import get_body, solar_system_ephemeris, EarthLocation
 
-    # Example usage of the EphemerisFlagger class
     ephemeris_flagger = EphemerisFlagger()
 
-    celestial_bodies = ["Jupiter", "Saturn", "Mars", "Ceres"]
-    proximity_thresholds = [Angle(0.1, unit=u.degree)] * len(celestial_bodies)
+    celestial_bodies = [
+        "Jupiter",
+    ]
+    proximity_thresholds = [Angle(0.5, unit=u.degree)] * len(celestial_bodies)
 
-    path = "/mn/stornext/d16/cmbco/comap/data/level1/2019-09/comap-0008000-2019-09-29-003017.hd5"
-
-    l1_data = {}
-    with h5py.File(path, "r") as infile:
-        for key, value in tqdm.tqdm(infile["spectrometer"].items()):
-            if key == "pixel_pointing":
-                for _key, _value in infile["spectrometer/pixel_pointing"].items():
-                    l1_data[_key] = _value[()]
-            elif key == "tod":
-                l1_data[key] = value[(0, 1), 0, 250]
-            else:
-                l1_data[key] = value[()]
-
-    ra = l1_data["pixel_ra"][(0, 1), :]
-    dec = l1_data["pixel_dec"][(0, 1), :]
-
+    observatory_time = Time(58755.028530304335, format="mjd", scale="tdb")
     observatory_pointing = SkyCoord(
-        ra=ra * u.deg, dec=dec * u.deg, frame="icrs"
-    ).transform_to("icrs")
-
-    observatory_time = Time(l1_data["MJD"], format="mjd", scale="utc").tdb
-
-    earth_file_data = np.loadtxt(
-        "/mn/stornext/d23/cmbco/globe/common/aux/ephemeris/earth_ephemeris.txt",
-        skiprows=2,
-    )
-    mjd_lr = Time(earth_file_data[:, 0], format="mjd", scale="tdb")
-    observatory_position_lr = SkyCoord(
-        x=earth_file_data[:, 1] * u.au,
-        y=earth_file_data[:, 2] * u.au,
-        z=earth_file_data[:, 3] * u.au,
-        representation_type="cartesian",
-        frame=HeliocentricMeanEcliptic,
+        ra=[256.82296228613416, 0, 90],
+        dec=[-22.609898786867273, 76, 43],
+        unit=u.deg,
+        frame="icrs",
     )
 
-    # Interpolating OVRO's (~Earth's) position to match the time array of the L1 data
-    earth_x_hr = np.interp(
-        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.x.to(u.km).value
-    )
-    earth_y_hr = np.interp(
-        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.y.to(u.km).value
-    )
-    earth_z_hr = np.interp(
-        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.z.to(u.km).value
-    )
-
-    observatory_position = SkyCoord(
-        x=earth_x_hr * u.km,
-        y=earth_y_hr * u.km,
-        z=earth_z_hr * u.km,
-        representation_type="cartesian",
-        frame=HeliocentricMeanEcliptic,
-    ).transform_to("icrs")
+    loc = EarthLocation.of_site("ovro")
+    with solar_system_ephemeris.set("builtin"):
+        earth = get_body("earth", observatory_time, loc)
+    observatory_position = earth.transform_to("heliocentricmeanecliptic")
 
     flags = ephemeris_flagger.generate_tod_flag(
         celestial_body_names=celestial_bodies,
@@ -371,58 +323,9 @@ def main2():
     )
 
     flags = np.array(flags)
-    print("\nFinished:", flags.shape)
-
-    fig, ax = plt.subplots()
-    ax.plot(observatory_time.mjd, flags[0, 0], label="Jupiter Flag")
-    ax.set_xlabel("MJD")
-    ax.set_ylabel("Flag")
-    ax.set_title("Proximity Flag for Jupiter")
-    ax.legend()
-    fig.savefig("jupiter_proximity_flag.png", dpi=300)
-
-    fig, ax = plt.subplots()
-    ax.plot(observatory_time.mjd, flags[1, 0], label="Saturn Flag")
-    ax.set_xlabel("MJD")
-    ax.set_ylabel("Flag")
-    ax.set_title("Proximity Flag for Saturn")
-    ax.legend()
-    fig.savefig("saturn_proximity_flag.png", dpi=300)
-
-    fig, ax = plt.subplots()
-    ax.plot(observatory_time.mjd, flags[2, 0], label="Mars Flag")
-    ax.set_xlabel("MJD")
-    ax.set_ylabel("Flag")
-    ax.set_title("Proximity Flag for Mars")
-    ax.legend()
-    fig.savefig("mars_proximity_flag.png", dpi=300)
-
-    fig, ax = plt.subplots()
-    ax.plot(observatory_time.mjd, flags[3, 0], label="Ceres Flag   ")
-    ax.set_xlabel("MJD")
-    ax.set_ylabel("Flag")
-    ax.set_title("Proximity Flag for Ceres")
-    ax.legend()
-    fig.savefig("ceres_proximity_flag.png", dpi=300)
-
-    fig, ax = plt.subplots()
-    ax.scatter(
-        dec[0, :],
-        ra[0, :],
-        c=flags[0, 0],
-        s=1,
-        label="Jupiter Proximity Flag",
-        cmap="viridis",
-    )
-    # Flip the x-axis to match the standard astronomical convention of increasing RA to the left
-    ax.invert_xaxis()
-    ax.set_xlabel("RA (deg)")
-    ax.set_ylabel("Dec (deg)")
-    ax.set_title("Jupiter Proximity Flag Map")
-    ax.legend()
-    fig.savefig("jupiter_proximity_flag_map.png", dpi=300)
+    print("Proximity Flags:", flags)
 
 
 if __name__ == "__main__":
-    # main()
+    main()
     main2()

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -17,12 +17,28 @@ from astropy.time import Time
 
 
 class EphemerisFlagger:
+    """Generate flags for celestial bodies based on proximity to observatory pointing.
+
+    This class loads ephemeris data for celestial bodies and generates boolean flags
+    indicating when the bodies are within a specified proximity threshold of the
+    observatory's pointing direction.
+    """
+
     def __init__(
         self,
         ephemeris_file_dir: Optional[
             str
         ] = "/mn/stornext/d23/cmbco/globe/common/aux/ephemeris",
     ):
+        """Initialize EphemerisFlagger with ephemeris data directory.
+
+        Args:
+            ephemeris_file_dir: Path to directory containing ephemeris data files.
+                Defaults to the common aux ephemeris directory.
+
+        Raises:
+            ValueError: If the provided directory path does not exist.
+        """
         if not os.path.isdir(ephemeris_file_dir):
             raise ValueError(f"Provided path {ephemeris_file_dir} is not a directory.")
 
@@ -32,6 +48,16 @@ class EphemerisFlagger:
         )
 
     def load_ephemeris(self, ephemeris_file: str):
+        """Load ephemeris data from file.
+
+        Args:
+            ephemeris_file: Path to ephemeris file containing time and position data.
+
+        Returns:
+            Tuple[Time, SkyCoord]: Tuple containing:
+                - ephemeris time as astropy Time object in TDB scale
+                - position as astropy SkyCoord in Heliocentric Mean Ecliptic frame
+        """
         ephemeris_data = np.loadtxt(ephemeris_file, skiprows=2)
         mjd = Time(ephemeris_data[:, 0], format="mjd", scale="tdb")
         pos = SkyCoord(
@@ -46,6 +72,23 @@ class EphemerisFlagger:
     def linearly_interpolate_ephemeris(
         self, ephemeris_time: Time, ephemeris_position: SkyCoord, target_time: Time
     ):
+        """Interpolate ephemeris position at a specific time.
+
+        Performs linear interpolation of celestial body position between ephemeris
+        data points at the requested time.
+
+        Args:
+            ephemeris_time: Array of times from ephemeris data (astropy Time).
+            ephemeris_position: Array of positions from ephemeris data (astropy SkyCoord).
+            target_time: Time at which to interpolate position (astropy Time).
+
+        Returns:
+            SkyCoord: Interpolated position at target time in the same frame as
+                ephemeris_position.
+
+        Raises:
+            ValueError: If target_time is outside the bounds of ephemeris data.
+        """
         if target_time < ephemeris_time[0] or target_time > ephemeris_time[-1]:
             raise ValueError("Target time is out of bounds of the ephemeris data.")
 
@@ -83,7 +126,27 @@ class EphemerisFlagger:
         observatory_time: Time,
         proximity_threshold: list[Angle],
     ):
+        """Generate proximity flags for celestial bodies.
 
+        Determines which celestial bodies are within specified proximity thresholds
+        of the observatory's pointing direction at a given time.
+
+        Args:
+            celestial_body_names: List of celestial body names (e.g., 'Jupiter', 'Saturn').
+            observatory_pointing: Observatory's pointing direction (astropy SkyCoord).
+            observatory_position: Observatory's position in space (astropy SkyCoord).
+            observatory_time: Time of observation (astropy Time).
+            proximity_threshold: List of angular separation thresholds for each body
+                (astropy Angle, same length as celestial_body_names).
+
+        Returns:
+            list: Boolean arrays indicating when each celestial body is within its
+                proximity threshold. Each array has same length as input time series.
+
+        Raises:
+            ValueError: If input coordinates are not SkyCoord objects or if
+                required ephemeris files are not found.
+        """
         # Ensure inputs are of the correct types
         if not isinstance(observatory_pointing, SkyCoord):
             raise ValueError("Observatory pointing must be an astropy SkyCoord object.")
@@ -191,6 +254,11 @@ class EphemerisFlagger:
 
 
 def main():
+    """Demonstrate usage of the EphemerisFlagger class with example data.
+
+    Creates an EphemerisFlagger instance, defines example celestial bodies and
+    observatory parameters, and generates proximity flags for the bodies.
+    """
     # Example usage of the EphemerisFlagger class
     ephemeris_flagger = EphemerisFlagger()
 

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -1,40 +1,19 @@
-from astropy.time import Time
-from astropy.coordinates import (
-    EarthLocation,
-    HeliocentricMeanEcliptic,
-    Galactic,
-    SkyCoord,
-    angular_separation,
-    Angle,
-)
-from astropy.coordinates import (
-    get_body_barycentric,
-    get_body,
-    SphericalRepresentation,
-    CartesianRepresentation,
-)
-import astropy.units as u
-from astropy.wcs import WCS
-from astropy.io import fits
-from astropy_healpix import HEALPix
-
-
-from astroquery.jplhorizons import Horizons
-from astroplan import Observer
-from astroplan.moon import moon_phase_angle
-
-import numpy as np
-import matplotlib.pyplot as plt
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-import h5py
 import glob
 import os
 from typing import Optional
 
+import astropy.units as u
+import numpy as np
 import tqdm
-
-from pixell import enmap, utils
-from cosmoglobe.tod_tools import TODLoader
+from astropy.coordinates import (
+    Angle,
+    CartesianRepresentation,
+    HeliocentricMeanEcliptic,
+    SkyCoord,
+    SphericalRepresentation,
+    angular_separation,
+)
+from astropy.time import Time
 
 
 class EphemerisFlagger:

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -5,6 +5,7 @@ from astropy.coordinates import (
     Galactic,
     SkyCoord,
     angular_separation,
+    Angle,
 )
 from astropy.coordinates import (
     get_body_barycentric,
@@ -72,17 +73,17 @@ class EphemerisFlagger:
         ephemeris_x = np.interp(
             target_time.tdb.mjd,
             ephemeris_time.tdb.mjd,
-            ephemeris_position.x.to(u.km).value,
+            ephemeris_position.cartesian.x.to(u.km).value,
         )
         ephemeris_y = np.interp(
             target_time.tdb.mjd,
             ephemeris_time.tdb.mjd,
-            ephemeris_position.y.to(u.km).value,
+            ephemeris_position.cartesian.y.to(u.km).value,
         )
         ephemeris_z = np.interp(
             target_time.tdb.mjd,
             ephemeris_time.tdb.mjd,
-            ephemeris_position.z.to(u.km).value,
+            ephemeris_position.cartesian.z.to(u.km).value,
         )
 
         interpolated_position = SkyCoord(
@@ -94,3 +95,143 @@ class EphemerisFlagger:
         )
 
         return interpolated_position
+
+    def generate_tod_flag(
+        self,
+        celestial_body_names: list[str],
+        observatory_pointing: SkyCoord,
+        observatory_position: SkyCoord,
+        observatory_time: Time,
+        proximity_threshold: list[Angle],
+    ):
+
+        # Ensure inputs are of the correct types
+        if not isinstance(observatory_pointing, SkyCoord):
+            raise ValueError("Observatory pointing must be an astropy SkyCoord object.")
+        if not isinstance(observatory_position, SkyCoord):
+            raise ValueError("Observatory position must be an astropy SkyCoord object.")
+        if not isinstance(observatory_time, Time):
+            raise ValueError("Observatory time must be an astropy Time object.")
+
+        if observatory_position.name != observatory_pointing.name:
+            observatory_position = observatory_position.transform_to(
+                observatory_pointing.name
+            )
+
+        celestial_body_names = [
+            name.casefold() for name in celestial_body_names
+        ]  # Normalize names to lowercase for consistent file naming
+
+        proximity_flags = []
+        # Looping through each celestial body to generate flags based on proximity to the observatory's pointing
+        for body in celestial_body_names:
+            if body not in [
+                os.path.basename(f).replace("_ephemeris.txt", "")
+                for f in self.available_ephemeris_files
+            ]:
+                raise ValueError(
+                    f"""Ephemeris file for {body} not found in directory. 
+                    Run ephemeris generator script to generate the required file."""
+                )
+
+            ephemeris_file = os.path.join(
+                self.ephemeris_file_dir, f"{body}_ephemeris.txt"
+            )
+
+            # Interpolating the celestial body's position at the observatory's time using the ephemeris data
+            ephemeris_time, ephemeris_position = self.load_ephemeris(ephemeris_file)
+
+            # Ensure all coordinates are in the same frame as the ovservatory pointing for accurate angular separation calculations
+            if ephemeris_position.name != observatory_pointing.name:
+                ephemeris_position = ephemeris_position.transform_to(
+                    observatory_pointing.name
+                )
+
+            body_position = self.linearly_interpolate_ephemeris(
+                ephemeris_time, ephemeris_position, observatory_time
+            )
+
+            # Translating the celestial body's position to the observatory's frame of reference by calculating the relative position
+            relative_cartesian_position = CartesianRepresentation(
+                body_position.cartesian.xyz.to(u.km)
+                - observatory_position.cartesian.xyz.to(u.km)
+            )
+
+            # Converting the relative position to spherical coordinates to calculate
+            # the apparent longitude and latitude of the celestial body as seen from the observatory
+            relative_spherical_position = SphericalRepresentation.from_cartesian(
+                relative_cartesian_position
+            )
+
+            # Calculating the angular separation between the observatory's pointing
+            # and the celestial body's apparent position
+            apparent_lon = relative_spherical_position.lon
+            apparent_lat = relative_spherical_position.lat
+
+            # Astropy SkyCoord's "longitude" and "latitude" component names depend on the frame,
+            # so we need to determine the correct component names for the observatory pointing
+            inverse_representation_component_names = {
+                v: k
+                for k, v in observatory_pointing.representation_component_names.items()
+            }
+
+            pointing_lon = getattr(
+                observatory_pointing, inverse_representation_component_names["lon"]
+            )
+            pointing_lat = getattr(
+                observatory_pointing, inverse_representation_component_names["lat"]
+            )
+
+            separation = angular_separation(
+                apparent_lon,
+                apparent_lat,
+                pointing_lon,
+                pointing_lat,
+            )
+
+            proximity_flag = (
+                separation < proximity_threshold[celestial_body_names.index(body)]
+            )
+
+            proximity_flags.append(proximity_flag)
+
+        return proximity_flags
+
+
+def main():
+    # Example usage of the EphemerisFlagger class
+    ephemeris_flagger = EphemerisFlagger()
+
+    celestial_bodies = ["Jupiter", "Saturn", "Mars"]
+    proximity_thresholds = [Angle(60, unit=u.degree)] * len(celestial_bodies)
+
+    # Example observatory parameters (these would typically come from the TOD data)
+    # observatory_pointing = SkyCoord(ra=150 * u.deg, dec=2 * u.deg, frame="icrs")
+    observatory_pointing = SkyCoord(
+        l=150 * u.deg,
+        b=2 * u.deg,
+        frame="galactic",
+        # lon=150 * u.deg, lat=2 * u.deg, frame="heliocentricmeanecliptic"
+    )
+    observatory_position = SkyCoord(
+        x=1 * u.au,
+        y=0 * u.au,
+        z=0 * u.au,
+        representation_type="cartesian",
+        frame="heliocentricmeanecliptic",
+    )
+    observatory_time = Time("2024-01-01T00:00:00", scale="tdb")
+
+    flags = ephemeris_flagger.generate_tod_flag(
+        celestial_body_names=celestial_bodies,
+        observatory_pointing=observatory_pointing,
+        observatory_position=observatory_position,
+        observatory_time=observatory_time,
+        proximity_threshold=proximity_thresholds,
+    )
+
+    print("Proximity Flags:", flags)
+
+
+if __name__ == "__main__":
+    main()

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -29,16 +29,19 @@ class EphemerisFlagger:
         ephemeris_file_dir: Optional[
             str
         ] = "/mn/stornext/d23/cmbco/globe/common/aux/ephemeris",
+        progressbar: bool = False,
     ):
         """Initialize EphemerisFlagger with ephemeris data directory.
 
         Args:
             ephemeris_file_dir: Path to directory containing ephemeris data files.
                 Defaults to the common aux ephemeris directory.
+            progressbar: If True, enables progressbar display during flag generation.
 
         Raises:
             ValueError: If the provided directory path does not exist.
         """
+        self.progressbar = progressbar
         if not os.path.isdir(ephemeris_file_dir):
             raise ValueError(f"Provided path {ephemeris_file_dir} is not a directory.")
 
@@ -169,18 +172,20 @@ class EphemerisFlagger:
 
         proximity_flags = []
 
-        pbar = tqdm.tqdm(
-            total=len(celestial_body_names),
-            desc="Processing",
-            colour="red",
-            ncols=80,
-            position=0,
-            leave=True,
-        )
+        if self.progressbar:
+            pbar = tqdm.tqdm(
+                total=len(celestial_body_names),
+                desc="Processing",
+                colour="red",
+                ncols=80,
+                position=0,
+                leave=True,
+            )
 
         # Looping through each celestial body to generate flags based on proximity to the observatory's pointing
         for body in celestial_body_names:
-            pbar.set_description(f"\033[92mProcessing {body}\033[00m")
+            if self.progressbar:
+                pbar.set_description(f"\033[92mProcessing {body}\033[00m")
 
             if body not in [
                 os.path.basename(f).replace("_ephemeris.txt", "")
@@ -243,8 +248,12 @@ class EphemerisFlagger:
             )
 
             proximity_flags.append(proximity_flag)
-            pbar.update(1)
-        pbar.close()
+            if self.progressbar:
+                pbar.update(1)
+
+        if self.progressbar:
+            pbar.close()
+
         return proximity_flags
 
 
@@ -294,7 +303,7 @@ def main2():
     import matplotlib.pyplot as plt
     from astropy.coordinates import get_body, solar_system_ephemeris, EarthLocation
 
-    ephemeris_flagger = EphemerisFlagger()
+    ephemeris_flagger = EphemerisFlagger(progressbar=True)
 
     celestial_bodies = [
         "Jupiter",

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -1,0 +1,96 @@
+from astropy.time import Time
+from astropy.coordinates import (
+    EarthLocation,
+    HeliocentricMeanEcliptic,
+    Galactic,
+    SkyCoord,
+    angular_separation,
+)
+from astropy.coordinates import (
+    get_body_barycentric,
+    get_body,
+    SphericalRepresentation,
+    CartesianRepresentation,
+)
+import astropy.units as u
+from astropy.wcs import WCS
+from astropy.io import fits
+from astropy_healpix import HEALPix
+
+
+from astroquery.jplhorizons import Horizons
+from astroplan import Observer
+from astroplan.moon import moon_phase_angle
+
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+import h5py
+import glob
+import os
+from typing import Optional
+
+import tqdm
+
+from pixell import enmap, utils
+from cosmoglobe.tod_tools import TODLoader
+
+
+class EphemerisFlagger:
+    def __init__(
+        self,
+        ephemeris_file_dir: Optional[
+            str
+        ] = "/mn/stornext/d23/cmbco/globe/common/aux/ephemeris",
+    ):
+        if not os.path.isdir(ephemeris_file_dir):
+            raise ValueError(f"Provided path {ephemeris_file_dir} is not a directory.")
+
+        self.ephemeris_file_dir = ephemeris_file_dir
+        self.available_ephemeris_files = glob.glob(
+            os.path.join(ephemeris_file_dir, "*.txt")
+        )
+
+    def load_ephemeris(self, ephemeris_file: str):
+        ephemeris_data = np.loadtxt(ephemeris_file, skiprows=2)
+        mjd = Time(ephemeris_data[:, 0], format="mjd", scale="tdb")
+        pos = SkyCoord(
+            x=ephemeris_data[:, 1] * u.au,
+            y=ephemeris_data[:, 2] * u.au,
+            z=ephemeris_data[:, 3] * u.au,
+            representation_type="cartesian",
+            frame=HeliocentricMeanEcliptic,
+        )
+        return mjd, pos
+
+    def linearly_interpolate_ephemeris(
+        self, ephemeris_time: Time, ephemeris_position: SkyCoord, target_time: Time
+    ):
+        if target_time < ephemeris_time[0] or target_time > ephemeris_time[-1]:
+            raise ValueError("Target time is out of bounds of the ephemeris data.")
+
+        ephemeris_x = np.interp(
+            target_time.tdb.mjd,
+            ephemeris_time.tdb.mjd,
+            ephemeris_position.x.to(u.km).value,
+        )
+        ephemeris_y = np.interp(
+            target_time.tdb.mjd,
+            ephemeris_time.tdb.mjd,
+            ephemeris_position.y.to(u.km).value,
+        )
+        ephemeris_z = np.interp(
+            target_time.tdb.mjd,
+            ephemeris_time.tdb.mjd,
+            ephemeris_position.z.to(u.km).value,
+        )
+
+        interpolated_position = SkyCoord(
+            x=ephemeris_x * u.km,
+            y=ephemeris_y * u.km,
+            z=ephemeris_z * u.km,
+            representation_type="cartesian",
+            frame=HeliocentricMeanEcliptic,
+        )
+
+        return interpolated_position

--- a/commander3/todscripts/AKARI/ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/ephemeris_flagging.py
@@ -89,7 +89,10 @@ class EphemerisFlagger:
         Raises:
             ValueError: If target_time is outside the bounds of ephemeris data.
         """
-        if target_time < ephemeris_time[0] or target_time > ephemeris_time[-1]:
+        if (
+            np.min(target_time.tdb.mjd) < ephemeris_time[0].tdb.mjd
+            or np.max(target_time.tdb.mjd) > ephemeris_time[-1].tdb.mjd
+        ):
             raise ValueError("Target time is out of bounds of the ephemeris data.")
 
         ephemeris_x = np.interp(
@@ -293,5 +296,133 @@ def main():
     print("Proximity Flags:", flags)
 
 
+def main2():
+
+    import h5py
+    from pixell import enmap, utils
+    import matplotlib.pyplot as plt
+
+    # Example usage of the EphemerisFlagger class
+    ephemeris_flagger = EphemerisFlagger()
+
+    celestial_bodies = ["Jupiter", "Saturn", "Mars", "Ceres"]
+    proximity_thresholds = [Angle(0.1, unit=u.degree)] * len(celestial_bodies)
+
+    path = "/mn/stornext/d16/cmbco/comap/data/level1/2019-09/comap-0008000-2019-09-29-003017.hd5"
+
+    l1_data = {}
+    with h5py.File(path, "r") as infile:
+        for key, value in tqdm.tqdm(infile["spectrometer"].items()):
+            if key == "pixel_pointing":
+                for _key, _value in infile["spectrometer/pixel_pointing"].items():
+                    l1_data[_key] = _value[()]
+            elif key == "tod":
+                l1_data[key] = value[(0, 1), 0, 250]
+            else:
+                l1_data[key] = value[()]
+
+    ra = l1_data["pixel_ra"][(0, 1), :]
+    dec = l1_data["pixel_dec"][(0, 1), :]
+
+    observatory_pointing = SkyCoord(
+        ra=ra * u.deg, dec=dec * u.deg, frame="icrs"
+    ).transform_to("icrs")
+
+    observatory_time = Time(l1_data["MJD"], format="mjd", scale="utc").tdb
+
+    earth_file_data = np.loadtxt(
+        "/mn/stornext/d23/cmbco/globe/common/aux/ephemeris/earth_ephemeris.txt",
+        skiprows=2,
+    )
+    mjd_lr = Time(earth_file_data[:, 0], format="mjd", scale="tdb")
+    observatory_position_lr = SkyCoord(
+        x=earth_file_data[:, 1] * u.au,
+        y=earth_file_data[:, 2] * u.au,
+        z=earth_file_data[:, 3] * u.au,
+        representation_type="cartesian",
+        frame=HeliocentricMeanEcliptic,
+    )
+
+    # Interpolating OVRO's (~Earth's) position to match the time array of the L1 data
+    earth_x_hr = np.interp(
+        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.x.to(u.km).value
+    )
+    earth_y_hr = np.interp(
+        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.y.to(u.km).value
+    )
+    earth_z_hr = np.interp(
+        l1_data["MJD"], mjd_lr.mjd, observatory_position_lr.z.to(u.km).value
+    )
+
+    observatory_position = SkyCoord(
+        x=earth_x_hr * u.km,
+        y=earth_y_hr * u.km,
+        z=earth_z_hr * u.km,
+        representation_type="cartesian",
+        frame=HeliocentricMeanEcliptic,
+    ).transform_to("icrs")
+
+    flags = ephemeris_flagger.generate_tod_flag(
+        celestial_body_names=celestial_bodies,
+        observatory_pointing=observatory_pointing,
+        observatory_position=observatory_position,
+        observatory_time=observatory_time,
+        proximity_threshold=proximity_thresholds,
+    )
+
+    flags = np.array(flags)
+    print("\nFinished:", flags.shape)
+
+    fig, ax = plt.subplots()
+    ax.plot(observatory_time.mjd, flags[0, 0], label="Jupiter Flag")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("Flag")
+    ax.set_title("Proximity Flag for Jupiter")
+    ax.legend()
+    fig.savefig("jupiter_proximity_flag.png", dpi=300)
+
+    fig, ax = plt.subplots()
+    ax.plot(observatory_time.mjd, flags[1, 0], label="Saturn Flag")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("Flag")
+    ax.set_title("Proximity Flag for Saturn")
+    ax.legend()
+    fig.savefig("saturn_proximity_flag.png", dpi=300)
+
+    fig, ax = plt.subplots()
+    ax.plot(observatory_time.mjd, flags[2, 0], label="Mars Flag")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("Flag")
+    ax.set_title("Proximity Flag for Mars")
+    ax.legend()
+    fig.savefig("mars_proximity_flag.png", dpi=300)
+
+    fig, ax = plt.subplots()
+    ax.plot(observatory_time.mjd, flags[3, 0], label="Ceres Flag   ")
+    ax.set_xlabel("MJD")
+    ax.set_ylabel("Flag")
+    ax.set_title("Proximity Flag for Ceres")
+    ax.legend()
+    fig.savefig("ceres_proximity_flag.png", dpi=300)
+
+    fig, ax = plt.subplots()
+    ax.scatter(
+        dec[0, :],
+        ra[0, :],
+        c=flags[0, 0],
+        s=1,
+        label="Jupiter Proximity Flag",
+        cmap="viridis",
+    )
+    # Flip the x-axis to match the standard astronomical convention of increasing RA to the left
+    ax.invert_xaxis()
+    ax.set_xlabel("RA (deg)")
+    ax.set_ylabel("Dec (deg)")
+    ax.set_title("Jupiter Proximity Flag Map")
+    ax.legend()
+    fig.savefig("jupiter_proximity_flag_map.png", dpi=300)
+
+
 if __name__ == "__main__":
-    main()
+    # main()
+    main2()

--- a/commander3/todscripts/AKARI/ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/ephemeris_generator.py
@@ -453,12 +453,103 @@ def parse_commandline_args():
     return parser.parse_args()
 
 
+def pretty_terminal_print():
+    """Print a cool stylized string saying "Ephemeris Gen" in ASCII art with rainbow colors."""
+    import colorsys
+
+    saturn_string = """                                                        
+                                    ▒▒▒▒▒▒▓▓▓▓                                   
+                                ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▓▓▓               ░▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒
+                                ░▒▒░░░░░░░░░░░░▒▒▒▒▒▒▓▓▓     ░▓▓▓▓█▓█▓▓▓▓▓▓▓▓░▓▓▓▓▒█
+                            ░░░░░░░░░░░░░░░░░░░░▒▒▒▒▓█▓▓▓██▓▓▒▒▒▓▓▓▓██▓▓▓▓░█▓▓▓█ 
+                            ░░░░░░░░░░░░░░░░░░░░░░░▒▒▒▒▓▓█     ░░▒░▒▓▓▓▓▓▓▓▒█▓▓▓   
+                            ░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▒▓██    ░▒░▓▓▓▓▓▓▓░▓▓▓▒░    
+                            ░░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▒▓█   ▒░▓▓▓▓▓▓▓▒▓▓▓▓       
+                        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▒▓██▒▒▓▓▓▓██░█▓▓▒█         
+                        ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▒▓████▓█▓▓▒▓▓▓▓█            
+                        ░░░░░░░░░░░░░░░░░░░░░░░░░░░▓▓███████▒▓▓▓▓▓               
+                        ░░░░░░░░░░░░░░░░░░░░░░░▒▓▓████████▓▓▓▓█                  
+                        ▓▒▓▓░░░░░░░░░░░     ░░░▒▓▓██████████▓▓▓                     
+                    ▓▒█▓▒░ ░░░░░░░    ░░░▒▒▒▓███▓███▓██████                        
+                ▒▓▓█▓▒░    ░░░░░░░░▒▒▒▒▓███████▓█████████                         
+                ▓▒▓▓▓▒▒░      ░▒▒▓▓▓▓████████▓██████▓▓███                           
+            ▓▓▒█▓▓▓▓▒░▒▒▒▒▒▒▒▓▓████████▓▓██████▓▓▓▓████                            
+        ▓▓▒█▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓█▓▓████████▓▒▒▒▓▓████                               
+        ▓▓▓░█▓▓▓▓▓▓▓▓▓█▓▓▓▓█▒░▓▓▓▓▓▓█░▓▓▓▓██████                                   
+        ▓▓▓█▓░▒▓█▓██▓▒░░▒▓▓▓▓▓▓▓█                                                   
+    ▓▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▒█░                                                        
+        ██▓▒▒▒▒▒▒▓█▓                                                                
+    """
+    # Write a cool stylized string saying "Ephemeris Gen" in ASCII art, and print it to the terminal.
+    pretty_string_art = r"""
+     /$$$$$$$$           /$$                                /$$$$$$                     
+    | $$_____/          | $$                               /$$__  $$                    
+    | $$        /$$$$$$ | $$$$$$$   /$$$$$$  /$$$$$$/$$$$ | $$  \__/  /$$$$$$  /$$$$$$$ 
+    | $$$$$    /$$__  $$| $$__  $$ /$$__  $$| $$_  $$_  $$| $$ /$$$$ /$$__  $$| $$__  $$
+    | $$__/   | $$  \ $$| $$  \ $$| $$$$$$$$| $$ \ $$ \ $$| $$|_  $$| $$$$$$$$| $$  \ $$
+    | $$      | $$  | $$| $$  | $$| $$_____/| $$ | $$ | $$| $$  \ $$| $$_____/| $$  | $$
+    | $$$$$$$$| $$$$$$$/| $$  | $$|  $$$$$$$| $$ | $$ | $$|  $$$$$$/|  $$$$$$$| $$  | $$
+    |________/| $$____/ |__/  |__/ \_______/|__/ |__/ |__/ \______/  \_______/|__/  |__/
+            | $$                                                                      
+            | $$                                                                      
+            |__/                                                                        
+                                                                                    
+    """
+
+    def _supports_truecolor() -> bool:
+        colorterm = os.environ.get("COLORTERM", "").casefold()
+        if "truecolor" in colorterm or "24bit" in colorterm:
+            return True
+        term = os.environ.get("TERM", "").casefold()
+        return "-direct" in term or "truecolor" in term
+
+    def _rgb_to_256(r: int, g: int, b: int) -> int:
+        r6 = int(round(r / 255 * 5))
+        g6 = int(round(g / 255 * 5))
+        b6 = int(round(b / 255 * 5))
+        return 16 + 36 * r6 + 6 * g6 + b6
+
+    def print_rainbow(text: str) -> None:
+        if os.environ.get("NO_COLOR") is not None:
+            print(text)
+            return
+
+        use_truecolor = _supports_truecolor()
+        chars: list[str] = []
+
+        for line in text.splitlines(keepends=True):
+            line_has_newline = line.endswith("\n")
+            line_content = line[:-1] if line_has_newline else line
+            count = max(len(line_content), 1)
+
+            for i, ch in enumerate(line_content):
+                hue = i / count
+                r, g, b = colorsys.hsv_to_rgb(hue, 1.0, 1.0)
+                r_i, g_i, b_i = int(r * 255), int(g * 255), int(b * 255)
+                if use_truecolor:
+                    color = f"\x1b[38;2;{r_i};{g_i};{b_i}m"
+                else:
+                    color = f"\x1b[38;5;{_rgb_to_256(r_i, g_i, b_i)}m"
+                chars.append(f"{color}{ch}")
+
+            chars.append("\x1b[0m")
+            if line_has_newline:
+                chars.append("\n")
+
+        print("".join(chars))
+
+    print_rainbow(saturn_string)
+    print_rainbow(pretty_string_art)
+
+
 def main() -> None:
     """Main entry point for ephemeris generation workflow.
 
     Parses command-line arguments, creates an EphemerisGenerator instance,
     runs the ephemeris generation pipeline, and saves results to disk.
     """
+
+    pretty_terminal_print()
 
     args = parse_commandline_args()
 

--- a/commander3/todscripts/AKARI/ephemeris_generator.py
+++ b/commander3/todscripts/AKARI/ephemeris_generator.py
@@ -100,9 +100,9 @@ class EphemerisGenerator:
         )
 
         self.jpl_horizons_query_limit = 90024
-        self.number_of_query_batches = max(1, int(
-            np.ceil(self.time_arr.size / self.jpl_horizons_query_limit)
-        ))
+        self.number_of_query_batches = max(
+            1, int(np.ceil(self.time_arr.size / self.jpl_horizons_query_limit))
+        )
         self.batch_size = int(
             np.ceil(self.time_arr.size / self.number_of_query_batches)
         )
@@ -359,7 +359,9 @@ class EphemerisGenerator:
                         grp["position_au"].attrs["units"] = "au"
                         grp["position_au"].attrs["frame"] = "heliocentric_mean_ecliptic"
             else:
-                print(f"Warning: Unknown format '{fmt}'. Skipping. Valid formats: txt, hdf5, h5, both")
+                print(
+                    f"Warning: Unknown format '{fmt}'. Skipping. Valid formats: txt, hdf5, h5, both"
+                )
 
 
 def parse_commandline_args():

--- a/commander3/todscripts/AKARI/unit_tests/test_ephemeris_flagging.py
+++ b/commander3/todscripts/AKARI/unit_tests/test_ephemeris_flagging.py
@@ -1,0 +1,567 @@
+"""Test suite for ephemeris_flagging.py module.
+
+This test suite includes unit tests for the EphemerisFlagger class and its methods.
+
+Usage Examples
+--------------
+
+Run all tests:
+    pytest test_ephemeris_flagging.py -v
+
+Run specific test class:
+    pytest test_ephemeris_flagging.py::TestEphemerisFlaggerInitialization -v
+
+Run specific test:
+    pytest test_ephemeris_flagging.py::TestEphemerisFlaggerInitialization::test_valid_directory -v
+
+Run tests with detailed output:
+    pytest test_ephemeris_flagging.py -vv -s
+
+Run with coverage report:
+    pytest test_ephemeris_flagging.py --cov=ephemeris_flagging --cov-report=html
+"""
+
+import sys
+import os
+import pytest
+import tempfile
+import numpy as np
+from unittest.mock import Mock, patch, MagicMock
+import astropy.units as u
+from astropy.time import Time
+from astropy.coordinates import SkyCoord, Angle, BarycentricMeanEcliptic
+
+# Add parent directory to path so we can import ephemeris_flagging
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ephemeris_flagging import EphemerisFlagger
+
+
+# ============================================================================
+# Initialization Tests
+# ============================================================================
+
+
+class TestEphemerisFlaggerInitialization:
+    """Test EphemerisFlagger initialization and setup."""
+
+    def test_valid_directory_initialization(self):
+        """Test initialization with a valid directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create some dummy ephemeris files
+            open(os.path.join(tmpdir, "jupiter_ephemeris.txt"), "w").close()
+            open(os.path.join(tmpdir, "saturn_ephemeris.txt"), "w").close()
+
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+
+            assert flagger.ephemeris_file_dir == tmpdir
+            assert len(flagger.available_ephemeris_files) == 2
+
+    def test_invalid_directory_raises_error(self):
+        """Test that invalid directory path raises ValueError."""
+        with pytest.raises(ValueError, match="is not a directory"):
+            EphemerisFlagger(ephemeris_file_dir="/nonexistent/path/to/directory")
+
+    def test_empty_directory_initialization(self):
+        """Test initialization with an empty directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+
+            assert flagger.ephemeris_file_dir == tmpdir
+            assert len(flagger.available_ephemeris_files) == 0
+
+    def test_multiple_ephemeris_files_detected(self):
+        """Test that multiple ephemeris files are correctly detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bodies = ["Jupiter", "Saturn", "Mars", "Mercury", "Venus"]
+            for body in bodies:
+                open(os.path.join(tmpdir, f"{body.lower()}_ephemeris.txt"), "w").close()
+
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+
+            assert len(flagger.available_ephemeris_files) == 5
+
+
+# ============================================================================
+# Ephemeris Loading Tests
+# ============================================================================
+
+
+class TestEphemerisLoading:
+    """Test ephemeris file loading and parsing."""
+
+    def create_sample_ephemeris_file(self, filepath, num_points=10):
+        """Create a sample ephemeris file for testing.
+
+        Args:
+            filepath: Path where to create the file.
+            num_points: Number of data points to create.
+        """
+        mjd_values = np.linspace(51544.0, 51553.0, num_points)  # Jan 1 to Jan 10, 2000
+        x_values = np.linspace(0.5, 1.5, num_points)  # AU
+        y_values = np.linspace(-0.2, 0.2, num_points)  # AU
+        z_values = np.linspace(-0.1, 0.1, num_points)  # AU
+
+        data = np.column_stack((mjd_values, x_values, y_values, z_values))
+
+        # Write with 2-line header (as expected by the loader)
+        with open(filepath, "w") as f:
+            f.write("Header line 1\n")
+            f.write("Header line 2\n")
+            np.savetxt(f, data)
+
+    def test_load_ephemeris_valid_file(self):
+        """Test loading a valid ephemeris file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ephemeris_file = os.path.join(tmpdir, "jupiter_ephemeris.txt")
+            self.create_sample_ephemeris_file(ephemeris_file)
+
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+            mjd, pos = flagger.load_ephemeris(ephemeris_file)
+
+            # Check returned types
+            assert isinstance(mjd, Time)
+            assert isinstance(pos, SkyCoord)
+
+            # Check data integrity
+            assert len(mjd) == 10
+            assert len(pos) == 10
+
+            # Check coordinate frame
+            assert pos.frame.name == "heliocentricmeanecliptic"
+
+    def test_load_ephemeris_time_format(self):
+        """Test that ephemeris time is in correct format (MJD, TDB scale)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ephemeris_file = os.path.join(tmpdir, "mars_ephemeris.txt")
+            self.create_sample_ephemeris_file(ephemeris_file, num_points=5)
+
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+            mjd, _ = flagger.load_ephemeris(ephemeris_file)
+
+            assert mjd.scale == "tdb"
+            # Check approximate values
+            assert np.allclose(mjd.mjd[0], 51544.0, atol=0.01)
+            assert np.allclose(mjd.mjd[-1], 51553.0, atol=0.01)
+
+    def test_load_ephemeris_position_units(self):
+        """Test that ephemeris positions are in correct units (AU)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ephemeris_file = os.path.join(tmpdir, "venus_ephemeris.txt")
+            self.create_sample_ephemeris_file(ephemeris_file, num_points=3)
+
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+            _, pos = flagger.load_ephemeris(ephemeris_file)
+
+            # Cartesian representation should be in AU
+            x_au = pos.cartesian.x[0].to(u.au).value
+            assert 0.4 < x_au < 0.6  # Should be ~0.5 AU
+
+
+# ============================================================================
+# Interpolation Tests
+# ============================================================================
+
+
+class TestEphemerisInterpolation:
+    """Test ephemeris position interpolation."""
+
+    def create_flagger_with_sample_data(self, tmpdir, num_points=5):
+        """Create a flagger and return it with sample ephemeris data."""
+        ephemeris_file = os.path.join(tmpdir, "jupiter_ephemeris.txt")
+
+        # Create predictable data for interpolation
+        mjd_values = np.array([51544.0, 51545.0, 51546.0, 51547.0, 51548.0])
+        x_values = np.array([1.0, 1.5, 2.0, 2.5, 3.0])  # Linear increase
+        y_values = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+        z_values = np.array([0.0, 0.0, 0.0, 0.0, 0.0])
+
+        data = np.column_stack((mjd_values, x_values, y_values, z_values))
+
+        with open(ephemeris_file, "w") as f:
+            f.write("Header line 1\n")
+            f.write("Header line 2\n")
+            np.savetxt(f, data)
+
+        flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+        return flagger, ephemeris_file
+
+    def test_interpolation_at_exact_time_point(self):
+        """Test interpolation at times that match ephemeris data points."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger, ephemeris_file = self.create_flagger_with_sample_data(tmpdir)
+            mjd, pos = flagger.load_ephemeris(ephemeris_file)
+
+            # Interpolate at an exact time point
+            target_time = Time(51545.0, format="mjd", scale="tdb")
+            interpolated = flagger.linearly_interpolate_ephemeris(mjd, pos, target_time)
+
+            assert isinstance(interpolated, SkyCoord)
+            # Should match the exact value
+            assert np.allclose(
+                interpolated.cartesian.x.to(u.km).value, 1.5 * u.au.to(u.km)
+            )
+
+    def test_interpolation_between_time_points(self):
+        """Test interpolation at times between ephemeris data points."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger, ephemeris_file = self.create_flagger_with_sample_data(tmpdir)
+            mjd, pos = flagger.load_ephemeris(ephemeris_file)
+
+            # Interpolate at midpoint between two data points
+            target_time = Time(51544.5, format="mjd", scale="tdb")
+            interpolated = flagger.linearly_interpolate_ephemeris(mjd, pos, target_time)
+
+            # Should be approximately halfway between 1.0 and 1.5
+            x_value = interpolated.cartesian.x.to(u.km).value
+            expected = 1.25 * u.au.to(u.km)
+            assert np.allclose(x_value, expected, rtol=0.01)
+
+    def test_interpolation_out_of_bounds_raises_error(self):
+        """Test that interpolation outside data bounds raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger, ephemeris_file = self.create_flagger_with_sample_data(tmpdir)
+            mjd, pos = flagger.load_ephemeris(ephemeris_file)
+
+            # Try to interpolate before the data range
+            target_time = Time(51543.0, format="mjd", scale="tdb")
+            with pytest.raises(ValueError, match="out of bounds"):
+                flagger.linearly_interpolate_ephemeris(mjd, pos, target_time)
+
+            # Try to interpolate after the data range
+            target_time = Time(51549.0, format="mjd", scale="tdb")
+            with pytest.raises(ValueError, match="out of bounds"):
+                flagger.linearly_interpolate_ephemeris(mjd, pos, target_time)
+
+    def test_interpolation_preserves_frame(self):
+        """Test that interpolation preserves the coordinate frame."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger, ephemeris_file = self.create_flagger_with_sample_data(tmpdir)
+            mjd, pos = flagger.load_ephemeris(ephemeris_file)
+
+            target_time = Time(51545.5, format="mjd", scale="tdb")
+            interpolated = flagger.linearly_interpolate_ephemeris(mjd, pos, target_time)
+
+            assert interpolated.frame.name == pos.frame.name
+            assert interpolated.frame.name == "heliocentricmeanecliptic"
+
+
+# ============================================================================
+# Flag Generation Tests
+# ============================================================================
+
+
+class TestFlagGeneration:
+    """Test proximity flag generation."""
+
+    def create_test_setup(self, tmpdir):
+        """Create test files and objects for flag generation tests."""
+        # Create dummy ephemeris file for Jupiter
+        ephemeris_file = os.path.join(tmpdir, "jupiter_ephemeris.txt")
+
+        # Simple constant position data
+        mjd_values = np.linspace(51544.0, 51545.0, 5)
+        x_values = np.ones(5) * 1.0  # Constant 1 AU
+        y_values = np.zeros(5)
+        z_values = np.zeros(5)
+
+        data = np.column_stack((mjd_values, x_values, y_values, z_values))
+
+        with open(ephemeris_file, "w") as f:
+            f.write("Header line 1\n")
+            f.write("Header line 2\n")
+            np.savetxt(f, data)
+
+        flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+        return flagger
+
+    def test_generate_tod_flag_basic(self):
+        """Test basic flag generation with simple inputs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = self.create_test_setup(tmpdir)
+
+            # Simple test case - use spherical coordinates (ra, dec) for pointing
+            observatory_pointing = SkyCoord(
+                ra=0 * u.deg,
+                dec=0 * u.deg,
+                frame="icrs",
+            )
+            observatory_position = SkyCoord(
+                x=0 * u.au,
+                y=0 * u.au,
+                z=0 * u.au,
+                representation_type="cartesian",
+                frame="heliocentricmeanecliptic",
+            )
+            observatory_time = Time(51544.5, format="mjd", scale="tdb")
+            proximity_threshold = [Angle(90, unit=u.degree)]
+
+            flags = flagger.generate_tod_flag(
+                celestial_body_names=["jupiter"],
+                observatory_pointing=observatory_pointing,
+                observatory_position=observatory_position,
+                observatory_time=observatory_time,
+                proximity_threshold=proximity_threshold,
+            )
+
+            assert isinstance(flags, list)
+            assert len(flags) == 1
+            assert isinstance(flags[0], (bool, np.bool_))
+
+    def test_generate_tod_flag_invalid_pointing_type(self):
+        """Test that invalid pointing object type raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = self.create_test_setup(tmpdir)
+
+            with pytest.raises(ValueError, match="Observatory pointing"):
+                flagger.generate_tod_flag(
+                    celestial_body_names=["jupiter"],
+                    observatory_pointing="invalid",  # Invalid type
+                    observatory_position=SkyCoord(
+                        x=0 * u.au,
+                        y=0 * u.au,
+                        z=0 * u.au,
+                        representation_type="cartesian",
+                        frame="heliocentricmeanecliptic",
+                    ),
+                    observatory_time=Time(51544.5, format="mjd", scale="tdb"),
+                    proximity_threshold=[Angle(90, unit=u.degree)],
+                )
+
+    def test_generate_tod_flag_invalid_position_type(self):
+        """Test that invalid position object type raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = self.create_test_setup(tmpdir)
+
+            with pytest.raises(ValueError, match="Observatory position"):
+                flagger.generate_tod_flag(
+                    celestial_body_names=["jupiter"],
+                    observatory_pointing=SkyCoord(
+                        ra=0 * u.deg,
+                        dec=0 * u.deg,
+                        frame="icrs",
+                    ),
+                    observatory_position="invalid",  # Invalid type
+                    observatory_time=Time(51544.5, format="mjd", scale="tdb"),
+                    proximity_threshold=[Angle(90, unit=u.degree)],
+                )
+
+    def test_generate_tod_flag_invalid_time_type(self):
+        """Test that invalid time object type raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = self.create_test_setup(tmpdir)
+
+            with pytest.raises(ValueError, match="Observatory time"):
+                flagger.generate_tod_flag(
+                    celestial_body_names=["jupiter"],
+                    observatory_pointing=SkyCoord(
+                        ra=0 * u.deg,
+                        dec=0 * u.deg,
+                        frame="icrs",
+                    ),
+                    observatory_position=SkyCoord(
+                        x=0 * u.au,
+                        y=0 * u.au,
+                        z=0 * u.au,
+                        representation_type="cartesian",
+                        frame="heliocentricmeanecliptic",
+                    ),
+                    observatory_time="2024-01-01",  # Invalid type
+                    proximity_threshold=[Angle(90, unit=u.degree)],
+                )
+
+    def test_generate_tod_flag_missing_ephemeris_file(self):
+        """Test that missing ephemeris file raises ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+
+            with pytest.raises(ValueError, match="Ephemeris file"):
+                flagger.generate_tod_flag(
+                    celestial_body_names=["nonexistent_body"],
+                    observatory_pointing=SkyCoord(
+                        ra=0 * u.deg,
+                        dec=0 * u.deg,
+                        frame="icrs",
+                    ),
+                    observatory_position=SkyCoord(
+                        x=0 * u.au,
+                        y=0 * u.au,
+                        z=0 * u.au,
+                        representation_type="cartesian",
+                        frame="heliocentricmeanecliptic",
+                    ),
+                    observatory_time=Time(51544.5, format="mjd", scale="tdb"),
+                    proximity_threshold=[Angle(90, unit=u.degree)],
+                )
+
+    def test_generate_tod_flag_case_insensitive_body_names(self):
+        """Test that body names are case-insensitive."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flagger = self.create_test_setup(tmpdir)
+
+            # Should work with uppercase
+            flags = flagger.generate_tod_flag(
+                celestial_body_names=["JUPITER"],
+                observatory_pointing=SkyCoord(
+                    ra=0 * u.deg,
+                    dec=0 * u.deg,
+                    frame="icrs",
+                ),
+                observatory_position=SkyCoord(
+                    x=0 * u.au,
+                    y=0 * u.au,
+                    z=0 * u.au,
+                    representation_type="cartesian",
+                    frame="heliocentricmeanecliptic",
+                ),
+                observatory_time=Time(51544.5, format="mjd", scale="tdb"),
+                proximity_threshold=[Angle(90, unit=u.degree)],
+            )
+
+            assert len(flags) == 1
+
+
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
+class TestIntegration:
+    """Integration tests combining multiple components."""
+
+    def test_full_workflow(self):
+        """Test complete workflow from initialization to flag generation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create ephemeris files
+            for body_name in ["jupiter", "saturn"]:
+                ephemeris_file = os.path.join(tmpdir, f"{body_name}_ephemeris.txt")
+
+                mjd_values = np.linspace(51544.0, 51545.0, 10)
+                x_values = np.linspace(1.0, 1.5, 10)
+                y_values = np.linspace(-0.2, 0.2, 10)
+                z_values = np.linspace(-0.1, 0.1, 10)
+
+                data = np.column_stack((mjd_values, x_values, y_values, z_values))
+
+                with open(ephemeris_file, "w") as f:
+                    f.write("Header line 1\n")
+                    f.write("Header line 2\n")
+                    np.savetxt(f, data)
+
+            # Initialize flagger
+            flagger = EphemerisFlagger(ephemeris_file_dir=tmpdir)
+
+            # Load data
+            jupiter_time, jupiter_pos = flagger.load_ephemeris(
+                os.path.join(tmpdir, "jupiter_ephemeris.txt")
+            )
+            saturn_time, saturn_pos = flagger.load_ephemeris(
+                os.path.join(tmpdir, "saturn_ephemeris.txt")
+            )
+
+            # Interpolate
+            target_time = Time(51544.5, format="mjd", scale="tdb")
+            jupiter_interp = flagger.linearly_interpolate_ephemeris(
+                jupiter_time, jupiter_pos, target_time
+            )
+            saturn_interp = flagger.linearly_interpolate_ephemeris(
+                saturn_time, saturn_pos, target_time
+            )
+
+            assert isinstance(jupiter_interp, SkyCoord)
+            assert isinstance(saturn_interp, SkyCoord)
+
+            # Generate flags
+            flags = flagger.generate_tod_flag(
+                celestial_body_names=["jupiter", "saturn"],
+                observatory_pointing=SkyCoord(
+                    ra=0 * u.deg,
+                    dec=0 * u.deg,
+                    frame="icrs",
+                ),
+                observatory_position=SkyCoord(
+                    x=0 * u.au,
+                    y=0 * u.au,
+                    z=0 * u.au,
+                    representation_type="cartesian",
+                    frame="heliocentricmeanecliptic",
+                ),
+                observatory_time=target_time,
+                proximity_threshold=[
+                    Angle(90, unit=u.degree),
+                    Angle(90, unit=u.degree),
+                ],
+            )
+
+            assert len(flags) == 2
+
+    def test_coordinate_frame_invariance(self):
+        """Testing that known pointing and time yield correct flags
+        and that input coordinate system do not change the flags.
+        """
+        import h5py
+        from pixell import enmap, utils
+        import matplotlib.pyplot as plt
+        from astropy.coordinates import get_body, solar_system_ephemeris, EarthLocation
+
+        ephemeris_flagger = EphemerisFlagger()
+
+        celestial_bodies = [
+            "Jupiter",
+        ]
+        proximity_thresholds = [Angle(0.5, unit=u.degree)] * len(celestial_bodies)
+
+        # Using a known time and pointing where Jupiter should be within the proximity threshold
+        # as well as two pointings that should not
+        observatory_time = Time(58755.028530304335, format="mjd", scale="tdb")
+        observatory_pointing = SkyCoord(
+            ra=[256.82296228613416, 0, 90],
+            dec=[-22.609898786867273, 76, 43],
+            unit=u.deg,
+            frame="icrs",
+        )
+
+        # Get the observatory (COMAP telescope) position in heliocentric mean ecliptic frame
+        loc = EarthLocation.of_site("ovro")
+        with solar_system_ephemeris.set("builtin"):
+            earth = get_body("earth", observatory_time, loc)
+        observatory_position = earth.transform_to("heliocentricmeanecliptic")
+
+        # Generate test flags, only the first should be True
+        flags = ephemeris_flagger.generate_tod_flag(
+            celestial_body_names=celestial_bodies,
+            observatory_pointing=observatory_pointing,
+            observatory_position=observatory_position,
+            observatory_time=observatory_time,
+            proximity_threshold=proximity_thresholds,
+        )
+
+        # Assert that the first pointing is flagged as True (Jupiter within threshold) and the others are False
+        flags = np.array(flags)
+        assert flags[
+            0, 0
+        ], "Jupiter should be within the proximity threshold at this time and pointing."
+        assert not np.any(
+            flags[0, 1:]
+        ), "Only Jupiter should be within the proximity threshold at this time and pointing."
+
+        # Check that different input frames yeild the same flags (since the method should handle transformations internally)
+        frames = [
+            "galactic",
+            "fk4",
+            "fk5",
+            "barycentricmeanecliptic",
+        ]
+        reference_flags = flags.copy()  # Store the original flags for comparison
+        for frame in frames:
+            transformed_pointing = observatory_pointing.transform_to(frame)
+            flags = ephemeris_flagger.generate_tod_flag(
+                celestial_body_names=celestial_bodies,
+                observatory_pointing=transformed_pointing,
+                observatory_position=observatory_position,
+                observatory_time=observatory_time,
+                proximity_threshold=proximity_thresholds,
+            )
+            assert np.array_equal(
+                flags, reference_flags
+            ), f"Flags should be the same regardless of the frame used for the observatory pointing. Discrepancy found in {frame} frame."


### PR DESCRIPTION
Added scripts and corresponding unit tests for ephemeris flagging. The `ephemeris_flagging.py` script can be used to generate flags for any future survey, indicating whether an observatory or satellite is pointing close to a given solar system body. The user has to provide the observatory's position and pointing in astropy `SkyCoords`, as well as an astropy `Time` to specify when the observation is made. The result is an array of boolean flags indicating whether a chosen celestial body is close to the pointing of the observatory.