### PR TITLE
Calculated per-band spin axis

### DIFF
--- a/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
+++ b/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
@@ -207,20 +207,20 @@ class AKARITODReader:
 
     @staticmethod
     def _ring_spin_axis(vecs):
-        vecs = np.array(vecs)
-        outAng = np.array([0., 0.])
-        nsamps = min(100, len(vecs))
-        pair1 = random.sample(range(len(vecs)), nsamps)
-        pair2 = random.sample(range(len(vecs)), nsamps)
-        for a1, a2 in zip(pair1, pair2):
-            crossP = np.cross(vecs[a1], vecs[a2])
-            if(crossP[0] < 0):
-                crossP *= -1
-            theta1, phi1 = hp.vec2ang(crossP)
-            if(not math.isnan(theta1) and not math.isnan(phi1)):
-                outAng[0] += theta1[0]/nsamps
-                outAng[1] += phi1[0]/nsamps
-            else:
-                outAng[0] += outAng[0]/nsamps
-                outAng[1] += outAng[1]/nsamps
+
+        p = np.gradient(vecs, axis=0)
+        L = np.cross(vecs, p)
+        Ln = np.linalg.norm(L, axis=1, keepdims=True)
+
+        # Normalize
+        good = Ln[:,0] > 0
+        L[good] /= Ln[good]
+
+        # Flip vectors so that they all lie in positive x axis.
+        L[L[:,0] < 0] *= -1
+        theta, phi = hp.vec2ang(L.mean(axis=0))
+
+        outAng = np.array([theta[0], phi[0]])
+
+
         return outAng

--- a/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
+++ b/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
@@ -218,9 +218,14 @@ class AKARITODReader:
 
         # Flip vectors so that they all lie in positive x axis.
         L[L[:,0] < 0] *= -1
-        theta, phi = hp.vec2ang(L.mean(axis=0))
+        theta, phi = hp.vec2ang(np.nanmean(L, axis=0))
+        if np.any(~np.isfinite(L)):
+            print('found a nan', theta, phi)
 
-        outAng = np.array([theta[0], phi[0]])
+        if np.all(Ln == 0):
+            outAng = np.array([0,0])
+        else:
+            outAng = np.array([theta[0], phi[0]])
 
 
         return outAng

--- a/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
+++ b/commander3/python/commander_tools/tod_tools/akari_native_tod_reader.py
@@ -207,6 +207,18 @@ class AKARITODReader:
 
     @staticmethod
     def _ring_spin_axis(vecs):
+        """
+        vecs - ntod x 3 array, corresponding to pointing of a single AKARI detector.
+
+        Since the instrument scans along great circles, the spin angular momentum
+        of the pixels is relatively stable. We estimate this using the classical angular 
+        momentum formula and estimate the linear momentum per pointing.
+
+        In the case of undefined angular momentum, zero is returned.
+
+        Note that the spin axis may be flipped from the true spin angular momentum,
+        since we take the convention that the x-axis of the spin is positive.
+        """
 
         p = np.gradient(vecs, axis=0)
         L = np.cross(vecs, p)

--- a/commander3/todscripts/AKARI/akari_commander_data_adapter.py
+++ b/commander3/todscripts/AKARI/akari_commander_data_adapter.py
@@ -419,6 +419,8 @@ class AKARICommanderDataAdapter(CommanderDataAdapter):
             gads_flags = load_gads_flags(files[0], band)
             detlons, detlats = load_lonlat_pkl(files[0], band)
 #            print(gads_flags)
+
+            spin_axis_arr = np.zeros((2, len(self.band_dets[band])))
             for detidx, det in enumerate(self.band_dets[band]):
                 todreader_data[band][det] = {}
                 if self.should_compress:
@@ -435,6 +437,10 @@ class AKARICommanderDataAdapter(CommanderDataAdapter):
                                                                   c.galactic.b.value,
                                                                   lonlat=True)
 
+                vecs = c.galactic.cartesian.get_xyz().value.T
+                spin_axis_arr[:,detidx] = self.todreaders[band]._ring_spin_axis(vecs)
+
+            todreader_data[band]['spin_axis'] = spin_axis_arr.mean(axis=1)
 
 
             ra = curr_data['ra']
@@ -446,9 +452,6 @@ class AKARICommanderDataAdapter(CommanderDataAdapter):
                                                          lonlat=True)
 
 
-            vecs = c.galactic.cartesian.get_xyz().value.T
-            spin_axis = self.todreaders[band]._ring_spin_axis(vecs)
-            todreader_data[band]['spin_axis'] = spin_axis
 
             if 'start_time' not in todreader_data:
                 starttime = curr_data['aftime'][0]

--- a/commander3/todscripts/AKARI/akari_commander_data_adapter.py
+++ b/commander3/todscripts/AKARI/akari_commander_data_adapter.py
@@ -440,7 +440,13 @@ class AKARICommanderDataAdapter(CommanderDataAdapter):
                 vecs = c.galactic.cartesian.get_xyz().value.T
                 spin_axis_arr[:,detidx] = self.todreaders[band]._ring_spin_axis(vecs)
 
-            todreader_data[band]['spin_axis'] = spin_axis_arr.mean(axis=1)
+            if np.any(~np.isfinite(spin_axis_arr)):
+                mu = np.nanmean(spin_axis_arr, axis=1)
+                print('Got another nan', mu, start_idx,
+                        self.chunk_file_map[band][self.chunk_idx], c)
+            else:
+                mu = spin_axis_arr.mean(axis=1)
+            todreader_data[band]['spin_axis'] = mu
 
 
             ra = curr_data['ra']

--- a/commander3/todscripts/AKARI/fits2hdf.py
+++ b/commander3/todscripts/AKARI/fits2hdf.py
@@ -7,7 +7,7 @@ AKARI_FITS_DIR = '/mn/stornext/d23/cmbco/akari/akari_TSD/www.ir.isas.jaxa.jp/~ya
 
 OUTPATH = '/mn/stornext/d23/cmbco/globe/akari/tod/eirik_newhdf/'
 OUTPATH = '/mn/stornext/d23/cmbco/globe/akari/tod/duncan_testhdf/'
-NSIDE = 1024
+NSIDE = 8192
 NUM_SEGMENT_PROCESSES = 60
 # Do this if you want error messages
 #NUM_SEGMENT_PROCESSES = None

--- a/commander3/todscripts/AKARI/fits2hdf.py
+++ b/commander3/todscripts/AKARI/fits2hdf.py
@@ -7,14 +7,14 @@ AKARI_FITS_DIR = '/mn/stornext/d23/cmbco/akari/akari_TSD/www.ir.isas.jaxa.jp/~ya
 
 OUTPATH = '/mn/stornext/d23/cmbco/globe/akari/tod/eirik_newhdf/'
 OUTPATH = '/mn/stornext/d23/cmbco/globe/akari/tod/duncan_testhdf/'
-NSIDE = 2048
+NSIDE = 1024
 NUM_SEGMENT_PROCESSES = 60
 # Do this if you want error messages
 #NUM_SEGMENT_PROCESSES = None
 # You can run all together, but it's typically faster to start four different
 # instances, one for each band
 #BANDS = ['065', '090', '140', '160']
-BANDS = ['065']
+BANDS = ['140']
 
 def run_single_band_write(band):
     akari_comm_data_adapter = akari_commander_data_adapter.AKARICommanderDataAdapter(


### PR DESCRIPTION
Removes the boresight spin axis calculation, and uses the average angular momentum for all detectors so that the spin axis is at the center of each bands array.

Additionally calculates the analytical cross product rather than the random sampling of two pointings.